### PR TITLE
Configure backend to accept full api url

### DIFF
--- a/src/components/SettingsDrawer.vue
+++ b/src/components/SettingsDrawer.vue
@@ -53,10 +53,10 @@
 					<el-switch v-model="innerUseBackendProxy" active-color="#409EFF" inactive-color="#dcdfe6"></el-switch>
 				</el-form-item>
 				<el-form-item v-if="innerUseBackendProxy" label="Deepseek代理">
-					<el-input v-model="innerBackendUrlDeepseek" placeholder="请输入后端Deepseek代理地址"></el-input>
+					<el-input v-model="innerBackendUrlDeepseek" placeholder="请输入后端Deepseek代理完整地址（支持 https://... ）"></el-input>
 				</el-form-item>
 				<el-form-item v-if="innerUseBackendProxy" label="Gemini代理">
-					<el-input v-model="innerBackendUrlGemini" placeholder="请输入后端Gemini代理地址"></el-input>
+					<el-input v-model="innerBackendUrlGemini" placeholder="请输入后端Gemini代理完整地址（支持 https://... ）"></el-input>
 				</el-form-item>
 
 				<el-form-item label="温度">

--- a/src/utils/aiService.js
+++ b/src/utils/aiService.js
@@ -1,22 +1,34 @@
 import { callModelDeepseek } from './providers/deepseek';
 import { callModelGemini } from './providers/gemini';
 
+function normalizeApiUrl(apiUrl) {
+	if (!apiUrl) return apiUrl;
+	const trimmed = String(apiUrl).trim();
+	if (!trimmed) return trimmed;
+	if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) return trimmed;
+	if (trimmed.startsWith('//')) return 'https:' + trimmed;
+	if (trimmed.startsWith('/')) return trimmed;
+	return 'https://' + trimmed;
+}
+
 export function getProviderByApiUrl(apiUrl) {
-	if (!apiUrl) return 'deepseek';
-	if (apiUrl.includes('generativelanguage.googleapis.com')) return 'gemini';
-	if (apiUrl.includes('/gemini')) return 'gemini';
-	if (apiUrl.includes('siliconflow.cn')) return 'deepseek';
-	if (apiUrl.includes('deepseek.com')) return 'deepseek';
-	if (apiUrl.includes('volces.com')) return 'deepseek';
+	const u = normalizeApiUrl(apiUrl) || '';
+	if (!u) return 'deepseek';
+	if (u.includes('generativelanguage.googleapis.com')) return 'gemini';
+	if (u.includes('/gemini')) return 'gemini';
+	if (u.includes('siliconflow.cn')) return 'deepseek';
+	if (u.includes('deepseek.com')) return 'deepseek';
+	if (u.includes('volces.com')) return 'deepseek';
 	return 'deepseek';
 }
 
 export async function callAiModel({ provider, apiUrl, apiKey, model, messages, temperature = 0.7, maxTokens = 4096, signal, onChunk }) {
-	const effectiveProvider = provider || getProviderByApiUrl(apiUrl);
+	const normalizedUrl = normalizeApiUrl(apiUrl);
+	const effectiveProvider = provider || getProviderByApiUrl(normalizedUrl);
 	if (effectiveProvider === 'gemini') {
-		return callModelGemini({ apiUrl, apiKey, model, messages, temperature, maxTokens, signal, onChunk });
+		return callModelGemini({ apiUrl: normalizedUrl, apiKey, model, messages, temperature, maxTokens, signal, onChunk });
 	}
-	return callModelDeepseek({ apiUrl, apiKey, model, messages, temperature, maxTokens, signal, onChunk });
+	return callModelDeepseek({ apiUrl: normalizedUrl, apiKey, model, messages, temperature, maxTokens, signal, onChunk });
 }
 
 export function listModelsByProvider(provider) {


### PR DESCRIPTION
Update Deepseek/Gemini proxy input placeholders to accept full backend URLs, enabling direct use of cross-origin backends.

---
<a href="https://cursor.com/background-agent?bcId=bc-28e76d1e-519c-4fcd-b019-43302f4f6342">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-28e76d1e-519c-4fcd-b019-43302f4f6342">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

