### PR TITLE
Debug env property access in messagelist.vue

### DIFF
--- a/src/components/MessageList.vue
+++ b/src/components/MessageList.vue
@@ -1,7 +1,7 @@
 <template>
 	<el-main ref="container" :class="['message-list', 'flex-1', 'overflow-y-auto', 'p-5', showSidebar ? 'mt-16' : 'mt-0', 'md:mt-0', 'scrollbar', 'scrollbar-thumb-gray-500', 'scrollbar-track-gray-200']" @scroll="handleScroll">
 		<!-- Debug info (only in development) -->
-		<div v-if="process.env.NODE_ENV === 'development'" class="debug-info bg-yellow-100 p-2 mb-4 rounded text-xs">
+		<div v-if="isDevelopment" class="debug-info bg-yellow-100 p-2 mb-4 rounded text-xs">
 			<strong>Debug Info:</strong> Messages: {{ debugInfo.messagesLength }}, 
 			API Key: {{ debugInfo.hasApiKey }}, 
 			Backend Proxy: {{ debugInfo.useBackendProxy }}, 
@@ -168,6 +168,9 @@ export default {
 	},
 	emits: ['toggle-reasoning', 'copy-message', 'edit-message', 'regenerate-message', 'delete-message', 'open-settings', 'scroll-bottom-changed', 'focus-input', 'open-script-panel'],
 	computed: {
+		isDevelopment() {
+			return import.meta.env.DEV;
+		},
 		debugInfo() {
 			return {
 				messagesLength: this.messages?.length || 0,


### PR DESCRIPTION
Replace `process.env.NODE_ENV` with `import.meta.env.DEV` to fix a TypeError in Vue 3 with Vite.

---
<a href="https://cursor.com/background-agent?bcId=bc-43893069-3011-4354-9d97-0c997dbccfa5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-43893069-3011-4354-9d97-0c997dbccfa5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

