### PR TITLE
Investigate gemini model thought process display

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -459,7 +459,9 @@ export default {
           provider: this.provider,
           apiUrl: this.apiUrl,
           apiKey: this.apiKey,
-          model: this.provider === 'gemini' ? this.model : this.effectiveModel,
+          model: this.provider === 'gemini'
+            ? (this.useBackendProxy ? `${this.model}-streaming:thinking` : this.model)
+            : this.effectiveModel,
           messages: requestMessages,
           temperature: this.temperature,
           maxTokens: 4096,

--- a/src/utils/aiService.js
+++ b/src/utils/aiService.js
@@ -16,9 +16,20 @@ function ensureCompletionsEndpoint(apiUrl) {
 	const url = String(apiUrl).trim();
 	if (!url) return url;
 	
-	// If the URL already contains a completions endpoint, return as is
-	if (url.includes('/v1/chat/completions') || url.includes('/v3/chat/completions') || url.includes('/gemini') || url.includes('/deepseek')) {
+	// If the URL already contains a standard completions endpoint, return as is
+	if (url.includes('/v1/chat/completions') || url.includes('/v3/chat/completions')) {
 		return url;
+	}
+
+	// Route backend proxy paths to unified OpenAI-compatible endpoint per backend standard
+	if (url.includes('/api/gemini') || url.includes('/api/deepseek') || url.includes('/api/')) {
+		try {
+			if (url.startsWith('http://') || url.startsWith('https://')) {
+				const u = new URL(url);
+				return `${u.origin}/api/v1/chat/completions`;
+			}
+		} catch (_) {}
+		return '/api/v1/chat/completions';
 	}
 	
 	// Remove trailing slash if present


### PR DESCRIPTION
Enable Gemini streaming and reasoning display when using a backend proxy by standardizing proxy endpoint routing, model suffix, and SSE parsing.

The existing setup for Gemini with a backend proxy did not correctly display the "thinking process" or stream content. This was due to the frontend not sending the correct model suffix (`-streaming:thinking`) to trigger these features on the backend, and the SSE parsing not being robust enough to handle the unified OpenAI-compatible stream format from the proxy. The changes align the frontend with the expected backend proxy standard, allowing both streaming and reasoning content to be displayed.

---
<a href="https://cursor.com/background-agent?bcId=bc-e547b907-6edf-4d4f-8d5e-7fe24aa11a79">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e547b907-6edf-4d4f-8d5e-7fe24aa11a79">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

