### PR TITLE
Fix gemini reasoning double line break

### DIFF
--- a/src/utils/providers/gemini.js
+++ b/src/utils/providers/gemini.js
@@ -147,7 +147,13 @@ export async function callModelGemini({ apiUrl, apiKey, model, messages, tempera
 					if (delta?.reasoning_content !== undefined) {
 						newMessage.reasoning_content += delta.reasoning_content || '';
 					}
+					// Heuristic: when transitioning from reasoning to normal content, ensure
+					// reasoning ends with a visible paragraph break (two newlines) so that
+					// Markdown renders as intended.
 					if (delta?.content !== undefined) {
+						if (newMessage.reasoning_content && !newMessage.reasoning_content.endsWith('\n\n')) {
+							newMessage.reasoning_content += newMessage.reasoning_content.endsWith('\n') ? '\n' : '\n\n';
+						}
 						newMessage.content += delta.content || '';
 					}
 				} else if (typeof data.text === 'string') {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Ensure Gemini `reasoning_content` ends with two newlines for correct Markdown paragraph rendering.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This fixes a display issue where the thinking process (reasoning_content) would not visually separate from subsequent content due to missing double line breaks, as Gemini often expects `\n\n` for paragraph separation.

---
<a href="https://cursor.com/background-agent?bcId=bc-75101b39-b756-44b7-923b-2ad0fc121cc1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-75101b39-b756-44b7-923b-2ad0fc121cc1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

