### PR TITLE
Fix thought process line break rendering

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -133,6 +133,12 @@
   font-size: 0.95rem;
 }
 
+/* 为 Markdown 和 思考过程 内容的段落添加间距，保证双换行可见 */
+.markdown-content p,
+.reasoning-body p {
+  margin: 0.8em 0;
+}
+
 /* 新增全局字体覆盖，确保所有组件均使用游戏风格字体 */
 * {
   font-family: 'Source Han Sans', '思源黑体', sans-serif !important;


### PR DESCRIPTION
Add paragraph margins to correctly display double newlines in markdown and reasoning sections.

---
<a href="https://cursor.com/background-agent?bcId=bc-23821baf-36bd-4b00-b1ad-c1918a8d2296">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-23821baf-36bd-4b00-b1ad-c1918a8d2296">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

