### PR TITLE
Update proxy terminology and text

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -226,15 +226,15 @@ export default {
       } else if (this.apiUrl === 'https://ark.cn-beijing.volces.com/api/v3/chat/completions') {
         return '当前选择的是火山引擎接口 请使用火山引擎的Key';
       } else if (this.apiUrl && this.apiUrl.includes('/gemini')) {
-        return '当前选择的是后端代理的Gemini接口，请使用你的Gemini Key或服务端配置的Key';
+        return '当前选择的是神秘链接的Gemini接口，请使用你的Gemini Key或服务端配置的Key';
       } else if (this.apiUrl && this.apiUrl.includes('/deepseek')) {
-        return '当前选择的是后端代理的DeepSeek接口，请使用你的DeepSeek Key或服务端配置的Key';
+        return '当前选择的是神秘链接的DeepSeek接口，请使用你的DeepSeek Key或服务端配置的Key';
       } else {
         return '';
       }
     },
     effectiveModel() {
-      // 如果使用后端代理，直接返回模型名称，不需要转换
+      // 如果使用神秘链接，直接返回模型名称，不需要转换
       if (this.useBackendProxy) {
         return this.model;
       }
@@ -270,7 +270,7 @@ export default {
     if (this.provider === 'gemini' && !this.model) this.model = this.models[0];
     // 对于 DeepSeek，如果模型不在列表中，也选择第一个
     if (this.provider === 'deepseek' && !this.models.includes(this.model)) this.model = this.models[0];
-    // 若启用了后端代理，初始化时强制将 apiUrl 指向后端代理地址，避免误用直连官方地址
+    // 若启用了神秘链接，初始化时强制将 apiUrl 指向神秘链接地址，避免误用直连官方地址
     if (this.useBackendProxy) {
       this.apiUrl = this.provider === 'gemini' ? this.backendUrlGemini : this.backendUrlDeepseek;
       this.apiKey = '';
@@ -287,7 +287,7 @@ export default {
       document.body.style.overflow = newVal ? 'hidden' : '';
     },
     useBackendProxy() {
-      // 当后端代理设置改变时，重新加载模型列表
+      // 当神秘链接设置改变时，重新加载模型列表
       this.models = listModelsByProvider(this.provider, this.useBackendProxy);
       // 如果当前选择的模型不在新的模型列表中，选择第一个
       if (!this.models.includes(this.model)) {
@@ -396,7 +396,7 @@ export default {
     async sendMessage(isRegenerate = false) {
       console.log('[DEBUG] sendMessage called, isRegenerate:', isRegenerate);
       console.log('[DEBUG] Current state - isLoading:', this.isLoading, 'inputMessage:', this.inputMessage);
-      console.log('[DEBUG] Backend proxy mode:', this.useBackendProxy);
+      console.log('[DEBUG] 神秘链接模式:', this.useBackendProxy);
       
       this.abortController = new AbortController();
       

--- a/src/components/MessageList.vue
+++ b/src/components/MessageList.vue
@@ -32,17 +32,17 @@
 			<div class="empty-state text-center p-5">
 				<el-alert type="info" :closable="false" show-icon>
 					<template #title>
-						<div class="text-lg font-semibold text-primary">当前是后端代理模式，可能需要输入密码</div>
+						<div class="text-lg font-semibold text-primary">当前是神秘链接模式，需要配置连接信息</div>
 					</template>
 					<template #default>
 						<div class="text-base text-customGray">
-							当前使用后端代理模式，密码功能暂未实现，请稍后再试。
-							<br>
-							如需使用API Key模式，请点击右上角
+							当前使用神秘链接模式，请点击右上角
 							<el-button type="link" class="inline-block text-blue-500 p-0" @click="$emit('open-settings')">
 								<el-icon><Setting /></el-icon> 设置
 							</el-button>
-							按钮关闭后端代理模式
+							按钮配置神秘链接地址和功能密码。
+							<br>
+							如需使用API Key模式，请在设置中关闭神秘链接模式。
 						</div>
 					</template>
 				</el-alert>

--- a/src/components/SettingsDrawer.vue
+++ b/src/components/SettingsDrawer.vue
@@ -49,26 +49,26 @@
 				</el-form-item>
 
 				<el-divider></el-divider>
-				<el-form-item label="后端代理">
+				<el-form-item label="神秘链接">
 					<el-switch v-model="innerUseBackendProxy" active-color="#409EFF" inactive-color="#dcdfe6"></el-switch>
 				</el-form-item>
-				<el-form-item v-if="innerUseBackendProxy" label="Deepseek代理">
-					<el-input v-model="innerBackendUrlDeepseek" placeholder="请输入后端Deepseek代理完整地址（支持 https://... ）"></el-input>
+				<el-form-item v-if="innerUseBackendProxy" label="Deepseek神秘链接">
+					<el-input v-model="innerBackendUrlDeepseek" placeholder="请输入Deepseek神秘链接完整地址（支持 https://... ）"></el-input>
 				</el-form-item>
-				<el-form-item v-if="innerUseBackendProxy" label="Gemini代理">
-					<el-input v-model="innerBackendUrlGemini" placeholder="请输入后端Gemini代理完整地址（支持 https://... ）"></el-input>
+				<el-form-item v-if="innerUseBackendProxy" label="Gemini神秘链接">
+					<el-input v-model="innerBackendUrlGemini" placeholder="请输入Gemini神秘链接完整地址（支持 https://... ）"></el-input>
 				</el-form-item>
 				
 				<el-form-item v-if="innerUseBackendProxy" label="功能密码">
 					<el-input
 						v-model="innerFeaturePassword"
 						type="password"
-						placeholder="请输入后端功能密码"
+						placeholder="请输入神秘链接功能密码"
 						show-password
 						autocomplete="off"
 					></el-input>
 					<div class="mt-1 text-gray-600 text-sm">
-						此密码用于访问后端API的权限验证，请联系管理员获取
+						此密码用于访问神秘链接的权限验证，请联系管理员获取
 					</div>
 				</el-form-item>
 
@@ -230,9 +230,9 @@ export default {
 			} else if (this.apiUrl === 'https://ark.cn-beijing.volces.com/api/v3/chat/completions') {
 				return '当前选择的是火山引擎接口 请使用火山引擎的Key'
 			} else if (this.apiUrl && this.apiUrl.includes('/gemini')) {
-				return '当前选择的是后端代理的Gemini接口，请使用你的Gemini Key或服务端配置的Key'
+				return '当前选择的是神秘链接的Gemini接口，请使用你的Gemini Key或服务端配置的Key'
 			} else if (this.apiUrl && this.apiUrl.includes('/deepseek')) {
-				return '当前选择的是后端代理的DeepSeek接口，请使用你的DeepSeek Key或服务端配置的Key'
+				return '当前选择的是神秘链接的DeepSeek接口，请使用你的DeepSeek Key或服务端配置的Key'
 			} else {
 				return ''
 			}

--- a/src/utils/aiService.js
+++ b/src/utils/aiService.js
@@ -25,7 +25,7 @@ function ensureCompletionsEndpoint(apiUrl) {
 		return url;
 	}
 
-	// Route backend proxy paths to unified OpenAI-compatible endpoint per backend standard
+	// Route 神秘链接 paths to unified OpenAI-compatible endpoint per backend standard
 	if (url.includes('/api/gemini') || url.includes('/api/deepseek') || url.includes('/api/')) {
 		try {
 			if (url.startsWith('http://') || url.startsWith('https://')) {
@@ -84,7 +84,7 @@ export async function callAiModel({ provider, apiUrl, apiKey, model, messages, t
 export function listModelsByProvider(provider, useBackendProxy = false) {
 	if (provider === 'gemini') {
 		if (useBackendProxy) {
-			// 后端代理使用的模型列表
+			// 神秘链接使用的模型列表
 			return [
 				'gemini-2.5-flash',
 				'gemini-2.5-flash-lite',
@@ -102,7 +102,7 @@ export function listModelsByProvider(provider, useBackendProxy = false) {
 		}
 	}
 	if (useBackendProxy) {
-		// 后端代理使用的DeepSeek模型列表
+		// 神秘链接使用的DeepSeek模型列表
 		return [
 			'deepseek-chat',
 			'deepseek-reasoner'


### PR DESCRIPTION
Replace "代理" (proxy) with "神秘链接" (mysterious link) in the UI text to align with the project's theme and improve user engagement.

The user requested a more evocative and less technical term for the backend connection mode, specifically suggesting "神秘链接" (mysterious link) to fit the "sleep story" project theme. This change only affects user-facing text, keeping code variable names unchanged.

---
<a href="https://cursor.com/background-agent?bcId=bc-b65ce032-109e-44cc-8ae6-3d341bb2ad62">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b65ce032-109e-44cc-8ae6-3d341bb2ad62">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

