### PR TITLE
Fix imported archive title bug

### DIFF
--- a/src/utils/archive.js
+++ b/src/utils/archive.js
@@ -119,7 +119,7 @@ export function mergeImportedChats(importedChats = [], existingChats = []) {
       const branched = { ...importedChat }
       branched.id = importedChat.id || (Date.now() + Math.random())
       const titles = existingChats.map(c => c.title)
-      const baseTitle = target.title || importedChat.title || '新对话'
+      const baseTitle = importedChat.title || target.title || '新对话'
       branched.title = generateUniqueBranchTitle(baseTitle, titles)
       existingChats.splice(bestIndex, 0, branched)
       continue


### PR DESCRIPTION
Generate unique titles for non-overlapping imported chats to prevent them from being incorrectly labeled as 'conflicting title'.

---
<a href="https://cursor.com/background-agent?bcId=bc-22e713ba-d249-471c-9237-2a2b4759abba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-22e713ba-d249-471c-9237-2a2b4759abba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

