### PR TITLE
Migrate chat records to indexeddb

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "dependencies": {
         "@element-plus/icons-vue": "^2.3.1",
+        "dexie": "^4.0.8",
         "element-plus": "^2.1.0",
         "highlight.js": "^11.8.0",
         "html2pdf.js": "^0.10.1",
@@ -1294,6 +1295,12 @@
       "resolved": "https://registry.npmmirror.com/dayjs/-/dayjs-1.11.13.tgz",
       "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
       "license": "MIT"
+    },
+    "node_modules/dexie": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dexie/-/dexie-4.2.0.tgz",
+      "integrity": "sha512-OSeyyWOUetDy9oFWeddJgi83OnRA3hSFh3RrbltmPgqHszE9f24eUCVLI4mPg0ifsWk0lQTdnS+jyGNrPMvhDA==",
+      "license": "Apache-2.0"
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "html2pdf.js": "^0.10.1",
     "markdown-it": "^14.1.0",
     "marked": "^4.3.0",
-    "vue": "^3.2.0"
+    "vue": "^3.2.0",
+    "dexie": "^4.0.8"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^4.6.2",

--- a/src/utils/db.js
+++ b/src/utils/db.js
@@ -1,0 +1,115 @@
+import Dexie from 'dexie';
+
+// Database schema:
+// - conversations: { id (number|string), title (string), createdAt (string) }
+// - messages: { id (string), chatId (number|string), role (string), content (string), reasoning_content (string|undefined), isReasoningCollapsed (boolean|undefined), timestamp (string) }
+// - meta: { key (string primary), value (any) }
+
+class ChatDatabase extends Dexie {
+	conversations;
+	messages;
+	meta;
+
+	constructor() {
+		super('bs2_chat_db');
+		this.version(1).stores({
+			conversations: 'id, createdAt',
+			messages: 'id, chatId, timestamp',
+			meta: 'key'
+		});
+		this.conversations = this.table('conversations');
+		this.messages = this.table('messages');
+		this.meta = this.table('meta');
+	}
+}
+
+export const db = new ChatDatabase();
+
+// Meta helpers
+export async function getMeta(key, defaultValue = null) {
+	const rec = await db.meta.get(key);
+	return rec ? rec.value : defaultValue;
+}
+
+export async function setMeta(key, value) {
+	await db.meta.put({ key, value });
+}
+
+// Conversations
+export async function listConversations() {
+	return db.conversations.orderBy('createdAt').reverse().toArray();
+}
+
+export async function getConversation(id) {
+	return db.conversations.get(id);
+}
+
+export async function upsertConversation(conversation) {
+	await db.conversations.put(conversation);
+}
+
+export async function deleteConversation(id) {
+	await db.transaction('rw', db.messages, db.conversations, async () => {
+		await db.messages.where('chatId').equals(id).delete();
+		await db.conversations.delete(id);
+	});
+}
+
+// Messages
+export async function listMessagesByChat(chatId) {
+	return db.messages.where('chatId').equals(chatId).sortBy('timestamp');
+}
+
+export async function replaceMessagesForChat(chatId, messages) {
+	await db.transaction('rw', db.messages, async () => {
+		await db.messages.where('chatId').equals(chatId).delete();
+		if (Array.isArray(messages) && messages.length > 0) {
+			await db.messages.bulkPut(messages.map((m, idx) => ({
+				id: m.id || `${chatId}-${idx}-${Date.now()}`,
+				chatId,
+				role: m.role,
+				content: m.content,
+				reasoning_content: m.reasoning_content,
+				isReasoningCollapsed: m.isReasoningCollapsed,
+				timestamp: m.timestamp || new Date().toISOString(),
+			})));
+		}
+	});
+}
+
+export async function appendMessage(chatId, message) {
+	const msg = {
+		id: message.id || `${chatId}-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		chatId,
+		role: message.role,
+		content: message.content,
+		reasoning_content: message.reasoning_content,
+		isReasoningCollapsed: message.isReasoningCollapsed,
+		timestamp: message.timestamp || new Date().toISOString(),
+	};
+	await db.messages.put(msg);
+	return msg;
+}
+
+export async function deleteMessage(messageId) {
+	await db.messages.delete(messageId);
+}
+
+// Export/Import helpers (skeleton for later stages)
+export async function exportAllData() {
+	const [conversations, messages, meta] = await Promise.all([
+		db.conversations.toArray(),
+		db.messages.toArray(),
+		db.meta.toArray()
+	]);
+	return { conversations, messages, meta };
+}
+
+export async function clearAllData() {
+	await db.transaction('rw', db.conversations, db.messages, db.meta, async () => {
+		await db.messages.clear();
+		await db.conversations.clear();
+		await db.meta.clear();
+	});
+}
+

--- a/src/utils/migration.js
+++ b/src/utils/migration.js
@@ -1,0 +1,62 @@
+import { db, getMeta, setMeta, upsertConversation, replaceMessagesForChat, listConversations } from './db';
+
+const META_MIGRATED_KEY = 'migrated_to_idb_v1';
+
+function safeParse(json, fallback) {
+	try { return JSON.parse(json); } catch { return fallback; }
+}
+
+export async function detectOldData() {
+	const existing = localStorage.getItem('bs2_chat_history');
+	return !!existing;
+}
+
+export async function migrateIfNeeded() {
+	// If already migrated, skip
+	const migrated = await getMeta(META_MIGRATED_KEY, false);
+	if (migrated) return { skipped: true };
+
+	// If IndexedDB unavailable, throw so caller can fallback
+	if (typeof window === 'undefined' || !('indexedDB' in window)) {
+		throw new Error('IndexedDB not supported');
+	}
+
+	const raw = localStorage.getItem('bs2_chat_history');
+	if (!raw) {
+		await setMeta(META_MIGRATED_KEY, true);
+		return { skipped: true };
+	}
+	const chats = safeParse(raw, []);
+	if (!Array.isArray(chats)) {
+		await setMeta(META_MIGRATED_KEY, true);
+		return { skipped: true };
+	}
+
+	await db.transaction('rw', db.conversations, db.messages, async () => {
+		for (const chat of chats) {
+			if (!chat || chat.id == null) continue;
+			const conversation = {
+				id: chat.id,
+				title: chat.title || '新对话',
+				createdAt: chat.createdAt || new Date().toISOString(),
+			};
+			await upsertConversation(conversation);
+			const msgs = Array.isArray(chat.messages) ? chat.messages : [];
+			await replaceMessagesForChat(conversation.id, msgs);
+		}
+	});
+
+	await setMeta(META_MIGRATED_KEY, true);
+	return { migrated: true, conversations: await listConversations() };
+}
+
+export async function loadChatsFromDb() {
+	const conversations = await listConversations();
+	const results = [];
+	for (const c of conversations) {
+		const msgs = await db.messages.where('chatId').equals(c.id).sortBy('timestamp');
+		results.push({ id: c.id, title: c.title, createdAt: c.createdAt, messages: msgs });
+	}
+	return results;
+}
+


### PR DESCRIPTION
Migrate chat history from `localStorage` to `IndexedDB` to enable robust local file attachment and storage management features.

This change is a foundational step towards implementing local file upload and storage. `IndexedDB` provides a more suitable and scalable solution for managing larger datasets, including binary file attachments, compared to the `localStorage` previously used for chat history.

---
<a href="https://cursor.com/background-agent?bcId=bc-1063220f-3b55-4776-bbc2-40f1389b52a2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1063220f-3b55-4776-bbc2-40f1389b52a2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

