### PR TITLE
Gemini gpt models

### DIFF
--- a/src/core/services/aiService.js
+++ b/src/core/services/aiService.js
@@ -223,6 +223,7 @@ export function listModelsByProvider(provider, useBackendProxy = false, apiUrl =
 			'google/gemini-3-pro-preview',
 			'google/gemini-3.1-pro-preview',
 			'google/gemini-3-flash-preview',
+			'google/gemini-3.1-flash-image-preview',
 			'anthropic/claude-sonnet-4.5',
 			'anthropic/claude-sonnet-4.6',
 			'anthropic/claude-3.5-sonnet',


### PR DESCRIPTION
Add `google/gemini-3.1-flash-image-preview` to the OpenRouter model list to make it available for selection.

---
<p><a href="https://cursor.com/agents/bc-19930787-b876-44f0-848a-569c7900d91f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-19930787-b876-44f0-848a-569c7900d91f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

