### PR TITLE
New OpenRouter models

### DIFF
--- a/src/core/services/aiService.js
+++ b/src/core/services/aiService.js
@@ -223,6 +223,7 @@ export function listModelsByProvider(provider, useBackendProxy = false, apiUrl =
 			'google/gemini-3-pro-preview',
 			'google/gemini-3.1-pro-preview',
 			'google/gemini-3-flash-preview',
+			'google/gemini-3.1-flash-lite-preview',
 			'google/gemini-3.1-flash-image-preview',
 			'anthropic/claude-sonnet-4.5',
 			'anthropic/claude-sonnet-4.6',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add `google/gemini-3.1-flash-lite-preview` to the list of OpenRouter models.

---
<p><a href="https://cursor.com/agents/bc-842dcb78-1703-424d-9d30-496b8ffe0a07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-842dcb78-1703-424d-9d30-496b8ffe0a07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->