### PR TITLE
feat(ai): add OpenRouter model anthropic/claude-opus-4.7

### DIFF
--- a/src/core/services/aiService.js
+++ b/src/core/services/aiService.js
@@ -230,6 +230,7 @@ export function listModelsByProvider(provider, useBackendProxy = false, apiUrl =
 			'anthropic/claude-3.5-sonnet',
 			'anthropic/claude-opus-4.5',
 			'anthropic/claude-opus-4.6',
+			'anthropic/claude-opus-4.7',
 			'openai/gpt-4o',
 			'openai/gpt-4o-mini',
 			'openai/gpt-5',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Add `anthropic/claude-opus-4.7` to the OpenRouter model list in `listModelsByProvider`, after the existing Opus 4.5 / 4.6 entries.

## Testing

- `npm install` and `npm run build` (local verification; `package-lock.json` not committed).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6e09d750-311a-4fe2-b741-f2cbdd4cf51b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e09d750-311a-4fe2-b741-f2cbdd4cf51b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

