### PR TITLE
Restore Gemini 3.1 OpenRouter models in AI list

### DIFF
--- a/src/core/services/aiService.js
+++ b/src/core/services/aiService.js
@@ -219,6 +219,8 @@ export function listModelsByProvider(provider, useBackendProxy = false, apiUrl =
 			'google/gemini-2.5-flash',
 			'google/gemini-2.5-pro',
 			'google/gemini-3-flash-preview',
+			'google/gemini-3.1-pro-preview',
+			'google/gemini-3.1-flash-image-preview',
 			'anthropic/claude-sonnet-4.5',
 			'anthropic/claude-sonnet-4.6',
 			'anthropic/claude-3.5-sonnet',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
在 `listModelsByProvider` 的 OpenRouter 分支中，于 `google/gemini-3-flash-preview` 之后重新加入：

- `google/gemini-3.1-pro-preview`
- `google/gemini-3.1-flash-image-preview`

本地已执行 `npm install` 与 `npm run build` 验证构建通过；提交中未包含 `package-lock.json` 变更。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8332bb25-9612-43de-b797-cf503b50833c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8332bb25-9612-43de-b797-cf503b50833c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

