### PR TITLE
添加 OpenRouter 模型 deepseek-v4-flash / deepseek-v4-pro

### DIFF
--- a/src/core/services/aiService.js
+++ b/src/core/services/aiService.js
@@ -242,7 +242,9 @@ export function listModelsByProvider(provider, useBackendProxy = false, apiUrl =
 			'deepseek/deepseek-r1-0528',
 			'deepseek/deepseek-r1-0528:free',
 			'deepseek/deepseek-v3.2',
-			'deepseek/deepseek-v3.2-speciale'
+			'deepseek/deepseek-v3.2-speciale',
+			'deepseek/deepseek-v4-flash',
+			'deepseek/deepseek-v4-pro'
 		];
 	}
 	


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
在 `listModelsByProvider` 的 OpenRouter 分支中增加 `deepseek/deepseek-v4-flash` 与 `deepseek/deepseek-v4-pro`，供模型下拉选择。

已通过 `npm ci` 与 `npm run build`。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-945a2625-2c44-4dae-80f4-8bc1b0e32756"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-945a2625-2c44-4dae-80f4-8bc1b0e32756"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

