### PR TITLE
Add generic game mode runtime

### DIFF
--- a/docs/通用游戏模式.md
+++ b/docs/通用游戏模式.md
@@ -1,0 +1,250 @@
+# 通用游戏模式
+
+通用游戏模式由两部分组成：
+
+- `GameMode`：运行时，负责状态、工具、触发器、AI 调用和对话保存。
+- 机制包：声明状态、工具、触发器、界面字段和主持人提示词。
+
+剧本只提供初始提示词。机制包还提供规则数据。
+
+## 文件位置
+
+- 模式入口：`src/modes/GameMode/`
+- 内置机制包：`src/gamePacks/builtin.js`
+- 机制包注册表：`src/gamePacks/index.js`
+- 运行时工具：`src/utils/gamePackRuntime.js`
+
+## 机制包结构
+
+```json
+{
+	"id": "my_pack",
+	"title": "我的机制包",
+	"version": 1,
+	"description": "显示在机制包选择器里的说明",
+	"turnPath": "world.turn",
+	"prompts": {
+		"host": "主持人提示词",
+		"rules": "规则提示词"
+	},
+	"initialState": {
+		"player": {
+			"hp": 10,
+			"maxHp": 10,
+			"inventory": []
+		},
+		"world": {
+			"turn": 0,
+			"location": "起点",
+			"locationTag": "town"
+		}
+	},
+	"ui": [
+		{ "type": "stat", "label": "生命值", "path": "player.hp", "maxPath": "player.maxHp" },
+		{ "type": "text", "label": "地点", "path": "world.location" },
+		{ "type": "list", "label": "背包", "path": "player.inventory" }
+	],
+	"tools": [
+		{
+			"id": "rollD20",
+			"type": "dice",
+			"label": "D20 检定",
+			"notation": "1d20"
+		},
+		{
+			"id": "randomEncounter",
+			"type": "table",
+			"label": "随机遭遇",
+			"entries": [
+				{ "weight": 3, "text": "一名商人请求帮助。" },
+				{ "weight": 1, "text": "道路上出现符文。", "patch": { "world.locationTag": "wild" } }
+			]
+		}
+	],
+	"triggers": [
+		{
+			"id": "wild-every-3-turns",
+			"label": "荒野随机遭遇",
+			"toolId": "randomEncounter",
+			"conditions": [
+				{ "path": "world.locationTag", "op": "eq", "value": "wild" },
+				{ "path": "world.turn", "op": "every", "value": 3 }
+			]
+		}
+	],
+	"openingMessage": "开场文本"
+}
+```
+
+## UI 字段
+
+`ui` 决定状态面板显示什么。
+
+| type | 字段 | 说明 |
+|---|---|---|
+| `stat` | `path`, `maxPath` | 数值条 |
+| `text` | `path` | 文本 |
+| `list` | `path` | 列表 |
+
+路径使用点号：
+
+```text
+player.hp
+world.location
+investigator.clues
+```
+
+## 工具
+
+当前支持两种工具。
+
+### dice
+
+```json
+{
+	"id": "rollD100",
+	"type": "dice",
+	"label": "D100 检定",
+	"notation": "1d100"
+}
+```
+
+支持格式：
+
+```text
+1d20
+2d6
+1d20+2
+1d100-10
+```
+
+### table
+
+```json
+{
+	"id": "strangeEvent",
+	"type": "table",
+	"label": "异常事件",
+	"entries": [
+		{ "weight": 4, "text": "窗外的雾气凝成一张脸。" },
+		{ "weight": 1, "text": "获得一页日志。", "patch": { "investigator.clues": ["日志残页"] } }
+	]
+}
+```
+
+`weight` 是权重。  
+`patch` 会写入状态。
+
+## 触发器
+
+触发器在玩家发送行动后检查。
+
+```json
+{
+	"id": "night-event",
+	"label": "夜间事件",
+	"toolId": "strangeEvent",
+	"conditions": [
+		{ "path": "world.locationTag", "op": "eq", "value": "night" },
+		{ "path": "world.turn", "op": "every", "value": 2 }
+	]
+}
+```
+
+支持的 `op`：
+
+| op | 说明 |
+|---|---|
+| `eq` | 等于 |
+| `neq` | 不等于 |
+| `gt` | 大于 |
+| `gte` | 大于等于 |
+| `lt` | 小于 |
+| `lte` | 小于等于 |
+| `truthy` | 为真 |
+| `falsy` | 为假 |
+| `includes` | 包含 |
+| `every` | 数值能被 value 整除 |
+
+## AI 返回格式
+
+GameMode 会要求 AI 返回 JSON：
+
+```json
+{
+	"narration": "给玩家看的正文",
+	"choices": ["行动一", "行动二"],
+	"statePatch": {
+		"player.hp": 8
+	},
+	"toolRequests": [
+		{
+			"toolId": "rollD20",
+			"reason": "潜行检定"
+		}
+	]
+}
+```
+
+字段说明：
+
+- `narration`：正文。
+- `choices`：可选行动。
+- `statePatch`：状态变更。
+- `toolRequests`：请求运行机制包工具。
+
+如果 AI 没有返回 JSON，GameMode 会把内容当普通文本保存。
+
+## 存档
+
+GameMode 写入两类数据：
+
+1. 对话文本。
+2. `chat.metadata.gameMode`。
+
+对话文本包含：
+
+```text
+【随机遭遇】
+...
+
+【状态变化】
+player.hp：10 → 8
+
+【可选行动】
+1. ...
+```
+
+结构化状态保存在：
+
+```js
+chat.metadata.gameMode = {
+	packId: 'builtin_dnd_adventure',
+	state: {}
+}
+```
+
+因此普通文本导出能阅读流程；完整存档能恢复状态。
+
+## 导入机制包
+
+游戏模式左侧可以导入 `.json`。
+
+支持：
+
+- 单个机制包对象
+- 机制包数组
+
+导入后写入浏览器本地：
+
+```text
+bs2_custom_game_packs
+```
+
+## 内置包
+
+当前内置：
+
+- `builtin_dnd_adventure`
+- `builtin_coc_investigation`
+

--- a/src/AppCore.vue
+++ b/src/AppCore.vue
@@ -206,7 +206,7 @@
 </template>
 
 <script>
-import { ChatDotRound } from '@element-plus/icons-vue';
+import { ChatDotRound, Trophy } from '@element-plus/icons-vue';
 import { pluginSystem } from '@/core/pluginSystem';
 import { registerAllModes, getAllModes } from '@/modes';
 import { registerAllTools } from '@/tools';
@@ -231,6 +231,7 @@ export default {
 	name: 'AppCore',
 	components: {
 		ChatDotRound,
+		Trophy,
 		ChatSidebar,
 		HeaderBar,
 		ModelSelector,

--- a/src/gamePacks/builtin.js
+++ b/src/gamePacks/builtin.js
@@ -1,0 +1,131 @@
+export const BUILTIN_GAME_PACKS = [
+	{
+		id: 'builtin_dnd_adventure',
+		title: 'DND 跑团基础包',
+		version: 1,
+		description: 'D20 检定、生命值、金币、背包、荒野随机遭遇。',
+		turnPath: 'world.turn',
+		prompts: {
+			host: '你是 DND 风格文本跑团主持人。你负责环境、NPC、战斗和检定时机。玩家没有明确要求时，不要替玩家做决定。',
+			rules: '当行动存在不确定性时，可以请求 rollD20。荒野、地城、危险区域可以结合已触发的随机遭遇推进。状态变化写入 statePatch。'
+		},
+		initialState: {
+			player: {
+				name: '冒险者',
+				hp: 12,
+				maxHp: 12,
+				gold: 10,
+				inventory: ['短剑', '火把', '干粮']
+			},
+			world: {
+				turn: 0,
+				location: '边境村庄',
+				locationTag: 'town',
+				quest: '寻找失踪的商队',
+				flags: {}
+			}
+		},
+		ui: [
+			{ type: 'stat', label: '生命值', path: 'player.hp', maxPath: 'player.maxHp' },
+			{ type: 'text', label: '地点', path: 'world.location' },
+			{ type: 'text', label: '任务', path: 'world.quest' },
+			{ type: 'text', label: '金币', path: 'player.gold' },
+			{ type: 'list', label: '背包', path: 'player.inventory' }
+		],
+		tools: [
+			{
+				id: 'rollD20',
+				type: 'dice',
+				label: 'D20 检定',
+				notation: '1d20'
+			},
+			{
+				id: 'wildEncounter',
+				type: 'table',
+				label: '荒野遭遇',
+				entries: [
+					{ weight: 5, text: '林间传来脚步声，一队哥布林正在争抢商队货箱。' },
+					{ weight: 3, text: '一名受伤商人靠在树下，请求玩家护送他回村。' },
+					{ weight: 2, text: '道路中央出现一枚发光符文，周围的鸟兽全部安静下来。' }
+				]
+			}
+		],
+		triggers: [
+			{
+				id: 'wild-every-3-turns',
+				label: '荒野随机遭遇',
+				toolId: 'wildEncounter',
+				conditions: [
+					{ path: 'world.locationTag', op: 'eq', value: 'wild' },
+					{ path: 'world.turn', op: 'every', value: 3 }
+				]
+			}
+		],
+		openingMessage: '你来到边境村庄。最近一支商队在北方森林失踪，村长愿意支付金币请人调查。你可以先询问村民、采购补给，或直接前往森林。'
+	},
+	{
+		id: 'builtin_coc_investigation',
+		title: 'COC 调查基础包',
+		version: 1,
+		description: '理智、线索、调查检定、异常事件表。',
+		turnPath: 'world.turn',
+		prompts: {
+			host: '你是 COC 风格调查主持人。你负责线索、氛围、NPC 和异常事件。保持信息递进，不要提前揭露真相。',
+			rules: '当玩家调查、聆听、说服、潜行或面对未知现象时，可以请求对应 D100 检定。理智变化写入 statePatch。'
+		},
+		initialState: {
+			investigator: {
+				name: '调查员',
+				hp: 10,
+				maxHp: 10,
+				sanity: 55,
+				maxSanity: 55,
+				clues: []
+			},
+			world: {
+				turn: 0,
+				location: '雾港镇旅馆',
+				locationTag: 'town',
+				case: '雾港镇失踪案',
+				flags: {}
+			}
+		},
+		ui: [
+			{ type: 'stat', label: '生命值', path: 'investigator.hp', maxPath: 'investigator.maxHp' },
+			{ type: 'stat', label: '理智', path: 'investigator.sanity', maxPath: 'investigator.maxSanity' },
+			{ type: 'text', label: '地点', path: 'world.location' },
+			{ type: 'text', label: '案件', path: 'world.case' },
+			{ type: 'list', label: '线索', path: 'investigator.clues' }
+		],
+		tools: [
+			{
+				id: 'rollD100',
+				type: 'dice',
+				label: 'D100 检定',
+				notation: '1d100'
+			},
+			{
+				id: 'strangeEvent',
+				type: 'table',
+				label: '异常事件',
+				entries: [
+					{ weight: 4, text: '窗外的雾气短暂凝成一张陌生人的脸。' },
+					{ weight: 3, text: '旅馆走廊尽头响起湿漉漉的脚步声，但没有人出现。' },
+					{ weight: 2, text: '一页被撕下的航海日志从门缝下滑进房间。', patch: { 'investigator.clues': ['航海日志残页'] } }
+				]
+			}
+		],
+		triggers: [
+			{
+				id: 'night-strange-event',
+				label: '夜间异常事件',
+				toolId: 'strangeEvent',
+				conditions: [
+					{ path: 'world.locationTag', op: 'eq', value: 'night' },
+					{ path: 'world.turn', op: 'every', value: 2 }
+				]
+			}
+		],
+		openingMessage: '雾港镇连续三晚有人失踪。你抵达镇上唯一的旅馆时，老板递来一把潮湿的钥匙，并说上一位住进这个房间的人再也没有回来。'
+	}
+];

--- a/src/gamePacks/index.js
+++ b/src/gamePacks/index.js
@@ -1,0 +1,124 @@
+import { BUILTIN_GAME_PACKS } from './builtin';
+
+const CUSTOM_GAME_PACKS_KEY = 'bs2_custom_game_packs';
+const ACTIVE_GAME_PACK_KEY = 'bs2_active_game_pack_id';
+
+function normalizeUiItems(items) {
+	return (Array.isArray(items) ? items : [])
+		.map(item => ({
+			type: item?.type || 'text',
+			label: item?.label || item?.path || '字段',
+			path: item?.path || '',
+			maxPath: item?.maxPath || ''
+		}))
+		.filter(item => item.path);
+}
+
+function normalizeTools(tools) {
+	return (Array.isArray(tools) ? tools : [])
+		.map(tool => ({
+			...tool,
+			id: String(tool?.id || '').trim(),
+			type: tool?.type === 'table' ? 'table' : 'dice',
+			label: tool?.label || tool?.id || '工具',
+			entries: Array.isArray(tool?.entries) ? tool.entries : []
+		}))
+		.filter(tool => tool.id);
+}
+
+function normalizeTriggers(triggers) {
+	return (Array.isArray(triggers) ? triggers : [])
+		.map(trigger => ({
+			id: String(trigger?.id || '').trim(),
+			label: trigger?.label || trigger?.id || '触发器',
+			toolId: String(trigger?.toolId || '').trim(),
+			conditions: Array.isArray(trigger?.conditions) ? trigger.conditions : []
+		}))
+		.filter(trigger => trigger.id && trigger.toolId);
+}
+
+export function normalizeGamePack(pack, source = 'custom') {
+	if (!pack || typeof pack !== 'object') return null;
+	const id = String(pack.id || '').trim();
+	if (!id) return null;
+	return {
+		id,
+		title: pack.title || id,
+		version: Number(pack.version || 1),
+		description: pack.description || '',
+		source,
+		turnPath: pack.turnPath || 'world.turn',
+		prompts: {
+			host: pack.prompts?.host || pack.prompt || '',
+			rules: pack.prompts?.rules || ''
+		},
+		initialState: pack.initialState && typeof pack.initialState === 'object' ? pack.initialState : {},
+		ui: normalizeUiItems(pack.ui),
+		tools: normalizeTools(pack.tools),
+		triggers: normalizeTriggers(pack.triggers),
+		openingMessage: pack.openingMessage || ''
+	};
+}
+
+export function getAllBuiltinGamePacks() {
+	return BUILTIN_GAME_PACKS
+		.map(pack => normalizeGamePack(pack, 'builtin'))
+		.filter(Boolean);
+}
+
+export function loadCustomGamePacks() {
+	try {
+		const raw = localStorage.getItem(CUSTOM_GAME_PACKS_KEY);
+		const parsed = raw ? JSON.parse(raw) : [];
+		return (Array.isArray(parsed) ? parsed : [])
+			.map(pack => normalizeGamePack(pack, 'custom'))
+			.filter(Boolean);
+	} catch {
+		return [];
+	}
+}
+
+export function saveCustomGamePacks(packs) {
+	const normalized = (Array.isArray(packs) ? packs : [])
+		.map(pack => normalizeGamePack(pack, 'custom'))
+		.filter(Boolean);
+	localStorage.setItem(CUSTOM_GAME_PACKS_KEY, JSON.stringify(normalized));
+	return normalized;
+}
+
+export function getAllGamePacks() {
+	return [...getAllBuiltinGamePacks(), ...loadCustomGamePacks()];
+}
+
+export function getGamePackById(id) {
+	return getAllGamePacks().find(pack => pack.id === id) || null;
+}
+
+export function importGamePacks(rawData, mode = 'merge') {
+	const source = Array.isArray(rawData) ? rawData : [rawData];
+	const imported = source
+		.map(pack => normalizeGamePack(pack, 'custom'))
+		.filter(Boolean);
+	if (!imported.length) return [];
+
+	if (mode === 'overwrite') {
+		saveCustomGamePacks(imported);
+		return imported;
+	}
+
+	const existing = loadCustomGamePacks();
+	const byId = new Map(existing.map(pack => [pack.id, pack]));
+	for (const pack of imported) {
+		byId.set(pack.id, pack);
+	}
+	saveCustomGamePacks(Array.from(byId.values()));
+	return imported;
+}
+
+export function loadActiveGamePackId() {
+	return localStorage.getItem(ACTIVE_GAME_PACK_KEY) || 'builtin_dnd_adventure';
+}
+
+export function saveActiveGamePackId(id) {
+	localStorage.setItem(ACTIVE_GAME_PACK_KEY, id);
+}

--- a/src/modes/GameMode/index.vue
+++ b/src/modes/GameMode/index.vue
@@ -1,0 +1,799 @@
+<template>
+	<div class="game-mode">
+		<aside class="game-panel">
+			<div class="panel-block">
+				<div class="panel-title">机制包</div>
+				<el-select
+					v-model="activePackId"
+					class="w-full"
+					placeholder="选择机制包"
+					:disabled="messages.length > 0"
+					@change="handlePackChange"
+				>
+					<el-option-group label="内置">
+						<el-option
+							v-for="pack in builtinPacks"
+							:key="pack.id"
+							:label="pack.title"
+							:value="pack.id"
+						/>
+					</el-option-group>
+					<el-option-group v-if="customPacks.length" label="导入">
+						<el-option
+							v-for="pack in customPacks"
+							:key="pack.id"
+							:label="pack.title"
+							:value="pack.id"
+						/>
+					</el-option-group>
+				</el-select>
+				<div class="panel-help">
+					{{ currentPack?.description || '导入机制包后，状态、工具和触发器会按包声明显示。' }}
+				</div>
+				<div class="panel-actions">
+					<el-button size="small" @click="openImportFile('merge')">导入包</el-button>
+					<el-button size="small" @click="exportCurrentPack">导出当前包</el-button>
+				</div>
+				<input
+					ref="importFile"
+					type="file"
+					accept=".json,application/json"
+					style="display: none;"
+					@change="handleImportFile"
+				/>
+			</div>
+
+			<div class="panel-block">
+				<div class="panel-title">状态</div>
+				<template v-if="currentPack?.ui?.length">
+					<div
+						v-for="item in currentPack.ui"
+						:key="`${item.type}-${item.path}`"
+						class="state-item"
+					>
+						<div class="state-label">{{ item.label }}</div>
+						<div v-if="item.type === 'stat'" class="state-stat">
+							<div class="state-stat-text">{{ formatPathValue(item.path) }} / {{ formatPathValue(item.maxPath) }}</div>
+							<div class="state-bar">
+								<div class="state-bar-fill" :style="{ width: `${getStatPercent(item)}%` }"></div>
+							</div>
+						</div>
+						<div v-else-if="item.type === 'list'" class="state-list">
+							<template v-if="getListValue(item.path).length">
+								<el-tag
+									v-for="entry in getListValue(item.path)"
+									:key="entry"
+									size="small"
+									effect="plain"
+								>
+									{{ entry }}
+								</el-tag>
+							</template>
+							<span v-else class="state-empty">空</span>
+						</div>
+						<div v-else class="state-value">{{ formatPathValue(item.path) }}</div>
+					</div>
+				</template>
+				<div v-else class="panel-help">当前机制包没有声明状态面板。</div>
+			</div>
+
+			<div class="panel-block">
+				<div class="panel-title">包工具</div>
+				<template v-if="currentPack?.tools?.length">
+					<el-button
+						v-for="tool in currentPack.tools"
+						:key="tool.id"
+						size="small"
+						class="tool-button"
+						@click="runManualTool(tool.id)"
+					>
+						{{ tool.label }}
+					</el-button>
+				</template>
+				<div v-else class="panel-help">当前机制包没有声明工具。</div>
+			</div>
+		</aside>
+
+		<div class="game-chat">
+			<el-main ref="container" class="message-list" @scroll="handleScroll">
+				<template v-if="!hasValidAuth && !messages.length">
+					<el-alert type="info" :closable="false" show-icon>
+						<template #title>
+							<div class="text-lg font-semibold text-primary">
+								{{ isBackendProxy ? '当前是后端代理模式，需要配置连接信息' : '请先设置 API Key' }}
+							</div>
+						</template>
+						<template #default>
+							<div class="text-base text-customGray">
+								点击右上角
+								<el-button type="link" class="inline-block text-blue-500 p-0" @click="$emit('open-settings')">
+									设置
+								</el-button>
+								配置接入信息。
+							</div>
+						</template>
+					</el-alert>
+				</template>
+
+				<EmptyState
+					v-else-if="!messages.length"
+					title="开始文本游戏"
+					:description="emptyDescription"
+				>
+					<template #actions>
+						<el-button class="btn-small" @click="insertOpeningMessage">使用机制包开场</el-button>
+						<el-button class="btn-small ml-2" @click="$emit('focus-input')">手动输入</el-button>
+					</template>
+				</EmptyState>
+
+				<template v-else>
+					<div
+						v-for="(msg, index) in messages"
+						:key="msg.id || index"
+						class="mb-6 flex flex-col"
+						:class="msg.role === 'user' ? 'items-end' : 'items-start'"
+					>
+						<MessageBubble
+							:role="msg.role"
+							:content="msg.content"
+							:reasoning-content="msg.reasoning_content"
+							:is-reasoning-collapsed="msg.isReasoningCollapsed"
+							:is-collapsed="msg.isCollapsed"
+						>
+							<template #controls="{ message }">
+								<MessageControls
+									:message="message"
+									:index="index"
+									:is-last="index === messages.length - 1"
+									:is-typing="isTyping"
+									@copy="$emit('copy-message', message.content)"
+									@edit="$emit('edit-message', index)"
+									@regenerate="$emit('regenerate-message')"
+									@delete="$emit('delete-message', index)"
+									@toggle-reasoning="$emit('toggle-reasoning', index)"
+									@fork="$emit('fork-chat', index)"
+									@toggle-collapse="toggleMessageCollapse(index)"
+								/>
+							</template>
+						</MessageBubble>
+					</div>
+
+					<div v-if="isTyping" class="message-bubble assistant-message">
+						<div class="typing-indicator">
+							<div class="dot" style="animation-delay: 0s"></div>
+							<div class="dot" style="animation-delay: 0.2s"></div>
+							<div class="dot" style="animation-delay: 0.4s"></div>
+						</div>
+					</div>
+				</template>
+			</el-main>
+
+			<ChatInput
+				v-model="inputMessage"
+				:disabled="!hasValidAuth"
+				:is-loading="isLoading"
+				:error-message="errorMessage"
+				placeholder="输入你的行动..."
+				@send="handleSend"
+				@cancel="handleCancel"
+				ref="inputRef"
+			/>
+		</div>
+	</div>
+</template>
+
+<script>
+import { ElMessage } from 'element-plus';
+import MessageBubble from '@/shared/components/MessageBubble.vue';
+import ChatInput from '@/shared/components/ChatInput.vue';
+import EmptyState from '@/shared/components/EmptyState.vue';
+import MessageControls from '@/modes/StandardChatMode/components/MessageControls.vue';
+import { callAiModel } from '@/core/services/aiService';
+import { createUuid } from '@/utils/chatData';
+import {
+	getAllGamePacks,
+	getGamePackById,
+	importGamePacks,
+	loadActiveGamePackId,
+	saveActiveGamePackId
+} from '@/gamePacks';
+import {
+	applyStatePatch,
+	buildGameAssistantContent,
+	buildGameSystemPrompt,
+	createDefaultGameState,
+	executeGameTool,
+	formatStateChanges,
+	formatToolResults,
+	getByPath,
+	getToolsById,
+	incrementTurn,
+	runGameTriggers,
+	safeParseGameResponse
+} from '@/utils/gamePackRuntime';
+
+export default {
+	name: 'GameMode',
+	components: {
+		MessageBubble,
+		ChatInput,
+		EmptyState,
+		MessageControls
+	},
+	props: {
+		config: {
+			type: Object,
+			default: () => ({})
+		},
+		chat: {
+			type: Object,
+			default: null
+		}
+	},
+	emits: [
+		'open-settings',
+		'focus-input',
+		'copy-message',
+		'edit-message',
+		'regenerate-message',
+		'delete-message',
+		'toggle-reasoning',
+		'update-chat',
+		'scroll-bottom-changed',
+		'scroll-progress',
+		'fork-chat'
+	],
+	data() {
+		return {
+			inputMessage: '',
+			isLoading: false,
+			isTyping: false,
+			errorMessage: '',
+			abortController: null,
+			isAtBottom: true,
+			activePackId: loadActiveGamePackId(),
+			packRevision: 0,
+			importMode: 'merge'
+		};
+	},
+	computed: {
+		apiKey() {
+			return this.config.apiKey || '';
+		},
+		isBackendProxy() {
+			return this.config.isBackendProxy || false;
+		},
+		hasValidAuth() {
+			return this.isBackendProxy || !!this.apiKey;
+		},
+		messages() {
+			return this.chat?.messages || [];
+		},
+		allPacks() {
+			this.packRevision;
+			return getAllGamePacks();
+		},
+		builtinPacks() {
+			return this.allPacks.filter(pack => pack.source === 'builtin');
+		},
+		customPacks() {
+			return this.allPacks.filter(pack => pack.source === 'custom');
+		},
+		currentPack() {
+			this.packRevision;
+			return getGamePackById(this.activePackId) || this.allPacks[0] || null;
+		},
+		gameData() {
+			return this.chat?.metadata?.gameMode || {};
+		},
+		gameState() {
+			return this.gameData.state || {};
+		},
+		emptyDescription() {
+			const packName = this.currentPack?.title || '未选择机制包';
+			return `当前机制包：${packName}。机制包决定状态面板、工具和触发器。`;
+		}
+	},
+	watch: {
+		chat: {
+			handler() {
+				this.syncPackFromChat();
+			},
+			immediate: true
+		}
+	},
+	mounted() {
+		this.ensureGameMetadata();
+	},
+	methods: {
+		createMessage(role, content, extra = {}) {
+			return {
+				id: createUuid(),
+				role,
+				content,
+				createdAt: new Date().toISOString(),
+				createdAtMs: Date.now(),
+				...extra
+			};
+		},
+		syncPackFromChat() {
+			const packId = this.chat?.metadata?.gameMode?.packId;
+			if (packId && getGamePackById(packId)) {
+				this.activePackId = packId;
+				saveActiveGamePackId(packId);
+			}
+			this.ensureGameMetadata();
+		},
+		ensureGameMetadata(force = false) {
+			if (!this.chat) return;
+			if (!this.chat.metadata) {
+				this.chat.metadata = {};
+			}
+			const pack = this.currentPack;
+			if (!pack) return;
+			const existing = this.chat.metadata.gameMode;
+			if (!existing || force) {
+				this.chat.metadata.gameMode = {
+					packId: pack.id,
+					state: createDefaultGameState(pack)
+				};
+				this.$emit('update-chat');
+				return;
+			}
+			if (!existing.state) {
+				existing.state = createDefaultGameState(pack);
+				this.$emit('update-chat');
+			}
+			if (!existing.packId) {
+				existing.packId = pack.id;
+				this.$emit('update-chat');
+			}
+		},
+		handlePackChange(packId) {
+			if (this.messages.length > 0) {
+				ElMessage.warning('当前对话已有消息，请新建对话后切换机制包');
+				this.activePackId = this.gameData.packId || loadActiveGamePackId();
+				return;
+			}
+			saveActiveGamePackId(packId);
+			this.ensureGameMetadata(true);
+			ElMessage.success('机制包已切换');
+		},
+		insertOpeningMessage() {
+			this.ensureGameMetadata();
+			if (!this.currentPack?.openingMessage) {
+				ElMessage.info('当前机制包没有开场文本');
+				return;
+			}
+			this.chat.messages.push(this.createMessage('assistant', this.currentPack.openingMessage, {
+				metadata: {
+					gameEvent: {
+						type: 'opening',
+						packId: this.currentPack.id
+					}
+				}
+			}));
+			this.$emit('update-chat');
+			this.scrollToBottom();
+		},
+		openImportFile(mode) {
+			this.importMode = mode;
+			this.$refs.importFile?.click();
+		},
+		handleImportFile(event) {
+			const file = event.target.files?.[0];
+			if (!file) return;
+			const reader = new FileReader();
+			reader.onload = (e) => {
+				try {
+					const parsed = JSON.parse(e.target.result);
+					const packs = importGamePacks(parsed, this.importMode);
+					this.packRevision += 1;
+					if (packs.length > 0) {
+						if (!this.messages.length) {
+							this.activePackId = packs[packs.length - 1].id;
+							saveActiveGamePackId(this.activePackId);
+							this.ensureGameMetadata(true);
+						} else {
+							this.activePackId = this.gameData.packId || this.activePackId;
+						}
+						ElMessage.success(`已导入 ${packs.length} 个机制包`);
+					}
+				} catch (error) {
+					ElMessage.error(`机制包导入失败：${error.message || '格式错误'}`);
+				}
+			};
+			reader.readAsText(file);
+			event.target.value = '';
+		},
+		exportCurrentPack() {
+			if (!this.currentPack) return;
+			const data = JSON.stringify(this.currentPack, null, 2);
+			const blob = new Blob([data], { type: 'application/json' });
+			const url = URL.createObjectURL(blob);
+			const a = document.createElement('a');
+			a.href = url;
+			a.download = `game_pack_${this.currentPack.id}.json`;
+			a.click();
+			URL.revokeObjectURL(url);
+		},
+		formatPathValue(path) {
+			return this.formatValue(getByPath(this.gameState, path, ''));
+		},
+		formatValue(value) {
+			if (Array.isArray(value)) return value.length ? value.join('、') : '空';
+			if (value && typeof value === 'object') return JSON.stringify(value);
+			if (value === undefined || value === null || value === '') return '空';
+			return String(value);
+		},
+		getListValue(path) {
+			const value = getByPath(this.gameState, path, []);
+			if (Array.isArray(value)) return value.map(item => this.formatValue(item));
+			if (value === undefined || value === null || value === '') return [];
+			return [this.formatValue(value)];
+		},
+		getStatPercent(item) {
+			const current = Number(getByPath(this.gameState, item.path, 0)) || 0;
+			const max = Number(getByPath(this.gameState, item.maxPath, 0)) || 0;
+			if (max <= 0) return 0;
+			return Math.min(100, Math.max(0, (current / max) * 100));
+		},
+		runManualTool(toolId) {
+			this.ensureGameMetadata();
+			const tool = getToolsById(this.currentPack)[toolId];
+			if (!tool) return;
+			try {
+				const result = executeGameTool(tool, this.gameState);
+				const content = formatToolResults([{ label: result.label, result }]);
+				this.chat.messages.push(this.createMessage('assistant', content, {
+					metadata: {
+						gameEvent: {
+							type: 'manualTool',
+							toolId,
+							result
+						}
+					}
+				}));
+				this.$emit('update-chat');
+				this.scrollToBottom();
+			} catch (error) {
+				ElMessage.error(error.message || '工具执行失败');
+			}
+		},
+		async handleSend() {
+			if (!this.inputMessage.trim() || this.isLoading) return;
+			this.ensureGameMetadata();
+			const pack = this.currentPack;
+			if (!pack) {
+				this.errorMessage = '请先选择机制包';
+				return;
+			}
+
+			const userInput = this.inputMessage.trim();
+			const userMessage = this.createMessage('user', userInput);
+			this.chat.messages.push(userMessage);
+			this.inputMessage = '';
+			this.isLoading = true;
+			this.isTyping = true;
+			this.errorMessage = '';
+			this.$emit('update-chat');
+
+			const state = this.gameState;
+			const turn = incrementTurn(state, pack);
+			const triggerResults = runGameTriggers(pack, state);
+			if (triggerResults.length) {
+				this.chat.messages.push(this.createMessage('assistant', formatToolResults(triggerResults.map(item => ({
+					label: item.label,
+					result: item.result
+				}))), {
+					metadata: {
+						gameEvent: {
+							type: 'triggers',
+							turn,
+							results: triggerResults
+						}
+					}
+				}));
+			}
+
+			const assistantMessage = this.createMessage('assistant', '');
+			this.chat.messages.push(assistantMessage);
+			this.$emit('update-chat');
+
+			try {
+				this.abortController = new AbortController();
+				const messagesForAi = [
+					{
+						role: 'system',
+						content: buildGameSystemPrompt(pack, state, triggerResults)
+					},
+					...this.chat.messages.slice(0, -1).map(message => ({
+						role: message.role,
+						content: message.content
+					}))
+				];
+				const result = await callAiModel({
+					provider: this.config.provider,
+					apiUrl: this.config.apiUrl,
+					apiKey: this.config.apiKey,
+					model: this.config.model,
+					messages: messagesForAi,
+					temperature: this.config.temperature,
+					maxTokens: this.config.maxTokens,
+					signal: this.abortController.signal,
+					featurePassword: this.config.featurePassword,
+					isBackendProxy: this.isBackendProxy,
+					geminiReasoningEffort: this.config.geminiReasoningEffort,
+					stream: false
+				});
+
+				const parsed = safeParseGameResponse(result?.content || '');
+				if (!parsed) {
+					assistantMessage.content = result?.content || '主持人没有返回内容。';
+					assistantMessage.metadata = {
+						gameEvent: {
+							type: 'plainResponse'
+						}
+					};
+				} else {
+					const toolResults = this.runRequestedTools(parsed.toolRequests || []);
+					const patchChanges = applyStatePatch(state, parsed.statePatch || {});
+					const toolChanges = toolResults.flatMap(item => item.changes || []);
+					const changes = [...toolChanges, ...patchChanges];
+					assistantMessage.content = buildGameAssistantContent({
+						narration: parsed.narration || '',
+						choices: parsed.choices || [],
+						toolResults,
+						changes
+					});
+					assistantMessage.metadata = {
+						gameEvent: {
+							type: 'gameResponse',
+							turn,
+							response: parsed,
+							toolResults,
+							changes
+						}
+					};
+				}
+				this.chat.messages = [...this.chat.messages];
+				this.$emit('update-chat');
+				if (this.chat.messages.length <= 3 && this.chat.title === '新对话') {
+					this.chat.title = userInput.substring(0, 20) + (userInput.length > 20 ? '...' : '');
+					this.$emit('update-chat');
+				}
+			} catch (error) {
+				const isAbort = error?.name === 'AbortError';
+				assistantMessage.content = isAbort ? '已取消，未生成更多内容。' : '主持人回复中断，未生成更多内容。';
+				this.errorMessage = isAbort ? '已取消' : (error.message || '发送失败，请重试');
+				this.inputMessage = userInput;
+				this.chat.messages = [...this.chat.messages];
+				this.$emit('update-chat');
+			} finally {
+				this.isLoading = false;
+				this.isTyping = false;
+				this.abortController = null;
+				this.scrollToBottom();
+			}
+		},
+		runRequestedTools(requests) {
+			const toolsById = getToolsById(this.currentPack);
+			const results = [];
+			for (const request of Array.isArray(requests) ? requests : []) {
+				const toolId = request?.toolId || request?.tool;
+				const tool = toolsById[toolId];
+				if (!tool) continue;
+				const result = executeGameTool(tool, this.gameState);
+				results.push({
+					...result,
+					label: request?.reason ? `${result.label}（${request.reason}）` : result.label
+				});
+			}
+			return results;
+		},
+		handleCancel() {
+			if (this.abortController) {
+				this.abortController.abort();
+			}
+		},
+		focus() {
+			this.$refs.inputRef?.focus();
+		},
+		handleScroll() {
+			this.emitScrollState();
+		},
+		emitScrollState() {
+			let container = this.$refs.container;
+			if (container && container.$el) container = container.$el;
+			if (!container) return;
+			const distanceFromBottom = container.scrollHeight - container.scrollTop - container.clientHeight;
+			this.isAtBottom = distanceFromBottom <= 50;
+			this.$emit('scroll-bottom-changed', distanceFromBottom > 150);
+			const maxScroll = container.scrollHeight - container.clientHeight;
+			const percent = maxScroll > 0 ? (container.scrollTop / maxScroll) * 100 : 0;
+			this.$emit('scroll-progress', Math.min(Math.max(percent, 0), 100));
+		},
+		scrollToBottom() {
+			this.$nextTick(() => {
+				let container = this.$refs.container;
+				if (container && container.$el) container = container.$el;
+				if (!container) return;
+				container.scrollTop = container.scrollHeight;
+				this.emitScrollState();
+			});
+		},
+		scrollToBottomManual() {
+			let container = this.$refs.container;
+			if (container && container.$el) container = container.$el;
+			if (!container) return;
+			container.scrollTop = container.scrollHeight;
+			this.emitScrollState();
+		},
+		getScrollStats() {
+			let container = this.$refs.container;
+			if (container && container.$el) container = container.$el;
+			if (!container) return { percent: 0 };
+			const maxScroll = container.scrollHeight - container.clientHeight;
+			const percent = maxScroll > 0 ? (container.scrollTop / maxScroll) * 100 : 0;
+			return { percent: Math.min(Math.max(percent, 0), 100) };
+		},
+		toggleMessageCollapse(index) {
+			if (!this.messages[index]) return;
+			this.messages[index].isCollapsed = !this.messages[index].isCollapsed;
+			this.$emit('update-chat');
+		}
+	}
+};
+</script>
+
+<style scoped>
+.game-mode {
+	display: flex;
+	height: 100%;
+	overflow: hidden;
+	background: #f9fafb;
+}
+
+.game-panel {
+	width: 18rem;
+	flex-shrink: 0;
+	overflow-y: auto;
+	border-right: 1px solid #e5e7eb;
+	background: #ffffff;
+	padding: 0.75rem;
+}
+
+.panel-block {
+	border: 1px solid #e5e7eb;
+	border-radius: 0.75rem;
+	background: #ffffff;
+	padding: 0.75rem;
+	margin-bottom: 0.75rem;
+}
+
+.panel-title {
+	font-size: 0.95rem;
+	font-weight: 600;
+	color: #111827;
+	margin-bottom: 0.5rem;
+}
+
+.panel-help {
+	font-size: 0.8rem;
+	color: #6b7280;
+	line-height: 1.5;
+	margin-top: 0.5rem;
+}
+
+.panel-actions {
+	display: flex;
+	gap: 0.5rem;
+	flex-wrap: wrap;
+	margin-top: 0.75rem;
+}
+
+.state-item {
+	padding: 0.5rem 0;
+	border-bottom: 1px solid #f3f4f6;
+}
+
+.state-item:last-child {
+	border-bottom: none;
+}
+
+.state-label {
+	font-size: 0.8rem;
+	color: #6b7280;
+	margin-bottom: 0.25rem;
+}
+
+.state-value,
+.state-stat-text {
+	font-size: 0.92rem;
+	color: #111827;
+	word-break: break-word;
+}
+
+.state-bar {
+	width: 100%;
+	height: 0.45rem;
+	background: #e5e7eb;
+	border-radius: 999px;
+	overflow: hidden;
+	margin-top: 0.3rem;
+}
+
+.state-bar-fill {
+	height: 100%;
+	background: #2563eb;
+	border-radius: 999px;
+}
+
+.state-list {
+	display: flex;
+	gap: 0.35rem;
+	flex-wrap: wrap;
+}
+
+.state-empty {
+	color: #9ca3af;
+	font-size: 0.85rem;
+}
+
+.tool-button {
+	margin: 0 0.35rem 0.35rem 0;
+}
+
+.game-chat {
+	flex: 1;
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+	background: #ffffff;
+}
+
+.message-list {
+	flex: 1;
+	overflow-y: auto;
+	overflow-x: hidden;
+	padding: 1.25rem;
+}
+
+.typing-indicator {
+	display: flex;
+	gap: 4px;
+}
+
+.dot {
+	width: 8px;
+	height: 8px;
+	background-color: #999;
+	border-radius: 50%;
+	animation: typing 1.4s infinite;
+}
+
+@keyframes typing {
+	0%, 60%, 100% {
+		transform: translateY(0);
+		opacity: 0.7;
+	}
+	30% {
+		transform: translateY(-10px);
+		opacity: 1;
+	}
+}
+
+@media (max-width: 768px) {
+	.game-mode {
+		flex-direction: column;
+	}
+
+	.game-panel {
+		width: 100%;
+		max-height: 38%;
+		border-right: none;
+		border-bottom: 1px solid #e5e7eb;
+	}
+}
+</style>

--- a/src/modes/GameMode/plugin.js
+++ b/src/modes/GameMode/plugin.js
@@ -1,0 +1,16 @@
+import GameMode from './index.vue';
+
+export default {
+	id: 'game-mode',
+	name: '游戏模式',
+	description: '通用文本游戏运行时，通过机制包决定状态、工具和触发器',
+	icon: 'Trophy',
+	version: '1.0.0',
+	author: 'tobenot',
+	component: GameMode,
+	config: {
+		supportReasoning: false,
+		supportStreaming: false,
+		supportMultiTurn: true
+	}
+};

--- a/src/modes/index.js
+++ b/src/modes/index.js
@@ -6,6 +6,7 @@
 import { pluginSystem } from '@/core/pluginSystem';
 import StandardChatMode from './StandardChatMode/plugin';
 import DrawMode from './DrawMode/plugin';
+import GameMode from './GameMode/plugin';
 
 // 注册所有模式插件
 export function registerAllModes() {
@@ -17,8 +18,10 @@ export function registerAllModes() {
 	// 注册绘图模式
 	pluginSystem.register(DrawMode);
 	
+	// 注册游戏模式
+	pluginSystem.register(GameMode);
+	
 	// 未来可以在这里注册更多模式：
-	// pluginSystem.register(GameMode);
 	// pluginSystem.register(NovelMode);
 	
 	console.log('[Modes] All modes registered:', pluginSystem.getAll().map(m => m.name));

--- a/src/utils/gamePackRuntime.js
+++ b/src/utils/gamePackRuntime.js
@@ -1,0 +1,266 @@
+import { createUuid } from '@/utils/chatData';
+
+const SUPPORTED_TOOL_TYPES = ['dice', 'table'];
+
+export function cloneData(value) {
+	return JSON.parse(JSON.stringify(value ?? null));
+}
+
+export function createDefaultGameState(pack) {
+	return cloneData(pack?.initialState || {});
+}
+
+export function getByPath(source, path, fallback = undefined) {
+	if (!path || typeof path !== 'string') return fallback;
+	const parts = path.split('.').filter(Boolean);
+	let current = source;
+	for (const part of parts) {
+		if (current === null || current === undefined) return fallback;
+		current = current[part];
+	}
+	return current === undefined ? fallback : current;
+}
+
+export function setByPath(target, path, value) {
+	if (!path || typeof path !== 'string') return;
+	const parts = path.split('.').filter(Boolean);
+	if (!parts.length) return;
+	let current = target;
+	for (let i = 0; i < parts.length - 1; i += 1) {
+		const part = parts[i];
+		if (!current[part] || typeof current[part] !== 'object') {
+			current[part] = {};
+		}
+		current = current[part];
+	}
+	current[parts[parts.length - 1]] = value;
+}
+
+export function applyStatePatch(state, patch) {
+	if (!patch) return [];
+	const changes = [];
+	const operations = Array.isArray(patch)
+		? patch
+		: Object.entries(patch).map(([path, value]) => ({ path, value }));
+
+	for (const operation of operations) {
+		if (!operation?.path) continue;
+		const previous = getByPath(state, operation.path, null);
+		const nextValue = operation.value;
+		setByPath(state, operation.path, nextValue);
+		changes.push({
+			path: operation.path,
+			from: previous,
+			to: nextValue
+		});
+	}
+	return changes;
+}
+
+export function incrementTurn(state, pack) {
+	const turnPath = pack?.turnPath || 'world.turn';
+	const currentTurn = Number(getByPath(state, turnPath, 0)) || 0;
+	setByPath(state, turnPath, currentTurn + 1);
+	return currentTurn + 1;
+}
+
+export function rollDice(notation = '1d20') {
+	const match = String(notation).trim().match(/^(\d*)d(\d+)([+-]\d+)?$/i);
+	if (!match) {
+		throw new Error(`不支持的骰子表达式：${notation}`);
+	}
+	const count = Math.max(1, parseInt(match[1] || '1', 10));
+	const sides = Math.max(2, parseInt(match[2], 10));
+	const modifier = parseInt(match[3] || '0', 10);
+	const rolls = [];
+	for (let i = 0; i < count; i += 1) {
+		rolls.push(Math.floor(Math.random() * sides) + 1);
+	}
+	const rawTotal = rolls.reduce((sum, value) => sum + value, 0);
+	return {
+		notation: `${count}d${sides}${modifier ? (modifier > 0 ? `+${modifier}` : `${modifier}`) : ''}`,
+		rolls,
+		modifier,
+		total: rawTotal + modifier
+	};
+}
+
+export function pickWeightedEntry(entries = []) {
+	const normalizedEntries = entries
+		.map(entry => ({
+			...entry,
+			weight: Math.max(0, Number(entry?.weight ?? 1) || 0)
+		}))
+		.filter(entry => entry.weight > 0);
+	const totalWeight = normalizedEntries.reduce((sum, entry) => sum + entry.weight, 0);
+	if (!totalWeight) return null;
+	let cursor = Math.random() * totalWeight;
+	for (const entry of normalizedEntries) {
+		cursor -= entry.weight;
+		if (cursor <= 0) return entry;
+	}
+	return normalizedEntries[normalizedEntries.length - 1] || null;
+}
+
+export function executeGameTool(tool, state) {
+	if (!tool || !SUPPORTED_TOOL_TYPES.includes(tool.type)) {
+		throw new Error('机制包工具不存在或类型不受支持');
+	}
+	if (tool.type === 'dice') {
+		const result = rollDice(tool.notation || '1d20');
+		return {
+			id: createUuid(),
+			toolId: tool.id,
+			type: 'dice',
+			label: tool.label || tool.id,
+			text: `${tool.label || tool.id}：${result.notation} = ${result.total} (${result.rolls.join(', ')}${result.modifier ? `, 修正 ${result.modifier}` : ''})`,
+			result
+		};
+	}
+
+	const entry = pickWeightedEntry(tool.entries || []);
+	if (!entry) {
+		throw new Error(`随机表没有可用条目：${tool.label || tool.id}`);
+	}
+	const changes = applyStatePatch(state, entry.patch);
+	return {
+		id: createUuid(),
+		toolId: tool.id,
+		type: 'table',
+		label: tool.label || tool.id,
+		text: `${tool.label || tool.id}：${entry.text || entry.label || '未命名结果'}`,
+		entry,
+		changes
+	};
+}
+
+function compareValues(left, op, right) {
+	if (op === 'eq') return left === right;
+	if (op === 'neq') return left !== right;
+	if (op === 'gt') return Number(left) > Number(right);
+	if (op === 'gte') return Number(left) >= Number(right);
+	if (op === 'lt') return Number(left) < Number(right);
+	if (op === 'lte') return Number(left) <= Number(right);
+	if (op === 'truthy') return Boolean(left);
+	if (op === 'falsy') return !left;
+	if (op === 'includes') return Array.isArray(left) ? left.includes(right) : String(left || '').includes(String(right));
+	if (op === 'every') {
+		const number = Number(left);
+		const interval = Number(right);
+		return interval > 0 && number > 0 && number % interval === 0;
+	}
+	return false;
+}
+
+export function shouldRunTrigger(trigger, state) {
+	const conditions = Array.isArray(trigger?.conditions) ? trigger.conditions : [];
+	if (!conditions.length) return false;
+	return conditions.every(condition => {
+		const value = getByPath(state, condition.path, null);
+		return compareValues(value, condition.op || 'eq', condition.value);
+	});
+}
+
+export function runGameTriggers(pack, state) {
+	const toolsById = getToolsById(pack);
+	const results = [];
+	for (const trigger of pack?.triggers || []) {
+		if (!shouldRunTrigger(trigger, state)) continue;
+		const tool = toolsById[trigger.toolId];
+		if (!tool) continue;
+		const result = executeGameTool(tool, state);
+		results.push({
+			triggerId: trigger.id,
+			label: trigger.label || result.label,
+			result
+		});
+	}
+	return results;
+}
+
+export function getToolsById(pack) {
+	const tools = Array.isArray(pack?.tools) ? pack.tools : [];
+	return tools.reduce((map, tool) => {
+		if (tool?.id) map[tool.id] = tool;
+		return map;
+	}, {});
+}
+
+export function safeParseGameResponse(text) {
+	const raw = String(text || '').trim();
+	if (!raw) return null;
+	const withoutFence = raw
+		.replace(/^```json\s*/i, '')
+		.replace(/^```\s*/i, '')
+		.replace(/```$/i, '')
+		.trim();
+	const firstBrace = withoutFence.indexOf('{');
+	const lastBrace = withoutFence.lastIndexOf('}');
+	if (firstBrace < 0 || lastBrace < firstBrace) return null;
+	return JSON.parse(withoutFence.slice(firstBrace, lastBrace + 1));
+}
+
+function formatValue(value) {
+	if (Array.isArray(value)) return value.join('、');
+	if (value && typeof value === 'object') return JSON.stringify(value);
+	if (value === undefined || value === null || value === '') return '空';
+	return String(value);
+}
+
+export function formatToolResults(results = []) {
+	return results
+		.map(item => `【${item.label || '工具结果'}】\n${item.result?.text || item.text || ''}`)
+		.join('\n\n');
+}
+
+export function formatStateChanges(changes = []) {
+	if (!changes.length) return '';
+	return [
+		'【状态变化】',
+		...changes.map(change => `${change.path}：${formatValue(change.from)} → ${formatValue(change.to)}`)
+	].join('\n');
+}
+
+export function formatChoices(choices = []) {
+	const normalized = Array.isArray(choices) ? choices.filter(Boolean) : [];
+	if (!normalized.length) return '';
+	return [
+		'【可选行动】',
+		...normalized.map((choice, index) => `${index + 1}. ${choice}`)
+	].join('\n');
+}
+
+export function buildGameAssistantContent({ narration, choices, toolResults, changes }) {
+	return [
+		narration || '',
+		formatToolResults(toolResults),
+		formatStateChanges(changes),
+		formatChoices(choices)
+	].filter(Boolean).join('\n\n');
+}
+
+export function buildGameSystemPrompt(pack, state, triggerResults = []) {
+	const responseSchema = {
+		narration: '给玩家看的正文',
+		choices: ['可选行动，允许为空数组'],
+		statePatch: { 'path.to.value': '新值，允许为空对象' },
+		toolRequests: [{ toolId: '工具ID', reason: '为什么需要工具' }]
+	};
+	const tools = (pack?.tools || []).map(tool => ({
+		id: tool.id,
+		type: tool.type,
+		label: tool.label,
+		notation: tool.notation
+	}));
+	return [
+		pack?.prompts?.host || pack?.prompt || '',
+		pack?.prompts?.rules || '',
+		'你是文本游戏主持人。根据玩家输入推进游戏。',
+		'只能返回 JSON，不要包裹 Markdown 代码块。',
+		`返回格式：${JSON.stringify(responseSchema)}`,
+		`当前机制包：${pack?.title || pack?.id || '未命名机制包'}`,
+		`当前状态：${JSON.stringify(state || {})}`,
+		tools.length ? `可请求工具：${JSON.stringify(tools)}` : '当前机制包没有声明工具。',
+		triggerResults.length ? `本回合已触发事件：${triggerResults.map(item => item.result?.text).filter(Boolean).join('；')}` : ''
+	].filter(Boolean).join('\n\n');
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a generic GameMode plugin that runs declarative mechanism packs.
- Add built-in DND and COC starter packs with state panels, dice/table tools, and triggers.
- Add game pack registry, runtime helpers, import/export support, and documentation.

## Verification
- npm run build
- node tests/branch-naming.test.mjs
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f2811416-8b55-40bc-9b57-a64776b0e6b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f2811416-8b55-40bc-9b57-a64776b0e6b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

