### PR TITLE
fix: TxtNovelExporter ReferenceError + 大存档滚动性能

### DIFF
--- a/src/components/TxtNovelExporter.vue
+++ b/src/components/TxtNovelExporter.vue
@@ -146,6 +146,7 @@
 <script>
 import { ref, watch } from 'vue';
 import { exportChatToTxtNovel } from '@/utils/txtExporter.js';
+import { safeGetLocalStorage, safeSetJsonLocalStorage, safeParseJson } from '@/utils/localStorageSafe.js';
 import { 
   InfoFilled, 
   Setting, 
@@ -221,7 +222,7 @@ export default {
         preserveLists: true,
       };
       
-      return savedOptions ? { ...defaultOptions, ...JSON.parse(savedOptions) } : defaultOptions;
+      return savedOptions ? { ...defaultOptions, ...safeParseJson(savedOptions, {}) } : defaultOptions;
     },
     
     async generatePreview() {

--- a/src/modes/StandardChatMode/index.vue
+++ b/src/modes/StandardChatMode/index.vue
@@ -203,7 +203,8 @@ export default {
 			errorMessage: '',
 			abortController: null,
 			isAtBottom: true,
-			throttledScroll: null
+			throttledScroll: null,
+			throttledHandleScroll: null
 		};
 	},
 	computed: {
@@ -243,21 +244,21 @@ export default {
 		}
 	},
 	watch: {
-		messages: {
-			handler(newMessages, oldMessages) {
-				if (newMessages.length > (oldMessages?.length || 0)) {
-					this.$nextTick(() => {
-						this.scrollToBottom();
-					});
-				}
-			},
-			deep: true
+		messages(newMessages, oldMessages) {
+			if (newMessages.length > (oldMessages?.length || 0)) {
+				this.$nextTick(() => {
+					this.scrollToBottom();
+				});
+			}
 		}
 	},
 	mounted() {
 		console.log('[StandardChatMode] Mounted');
 		this.throttledScroll = throttle(() => {
 			this.scrollToBottom();
+		}, 100);
+		this.throttledHandleScroll = throttle(() => {
+			this.emitScrollState();
 		}, 100);
 		this.$nextTick(() => {
 			this.emitScrollState();
@@ -290,7 +291,9 @@ export default {
 			return Math.round(cn * 1.25 + en * 0.35 + other * 0.6);
 		},
 		handleScroll() {
-			this.emitScrollState();
+			if (this.throttledHandleScroll) {
+				this.throttledHandleScroll();
+			}
 		},
 		emitScrollState() {
 			let container = this.$refs.container;

--- a/src/utils/chatStorage.js
+++ b/src/utils/chatStorage.js
@@ -1,3 +1,5 @@
+import { safeGetLocalStorage, safeRemoveLocalStorage } from './localStorageSafe.js';
+
 const CHAT_DB_NAME = 'bs2-chat-db';
 const CHAT_DB_VERSION = 2;
 const CHAT_STORE_NAME = 'kv';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

### Bug 1 — `ReferenceError: safeGetLocalStorage is not defined`

`TxtNovelExporter.vue` 在 `data()` 初始化时调用 `getDefaultOptions()`，而该方法里用到了 `safeGetLocalStorage` / `safeSetJsonLocalStorage`，但这两个函数从未被 import。组件一挂载就抛出 ReferenceError 导致整个 Vue 实例初始化失败。

### Bug 2 — 打开旧存档下滑卡死/崩溃

两处原因叠加：

1. `messages` watcher 带了 `deep: true`。切换到一个含大量消息的旧存档时，Vue 要对整个消息数组做深层遍历，对每条消息的每个属性注册响应式 getter/setter，对 500+ 条消息来说这是主线程阻塞的 O(n) 操作，且完全没有必要——watcher handler 只比较 `.length`。

2. `handleScroll` 未节流，每滚动一个像素就 `emitScrollState()`，后者向 AppCore 发出两个事件，触发 `showScrollToBottom` 和 `currentScrollPercent` 响应式更新，理论上达到 60fps 的更新频率。

### 额外发现 — `chatStorage.js` 缺少 import

`safeGetLocalStorage` / `safeRemoveLocalStorage` 在 legacy 迁移路径中被调用，但文件顶部没有 import。虽然该路径只在首次迁移时执行，但会导致迁移流程静默失败。

## 修改

| 文件 | 改动 |
|------|------|
| `src/components/TxtNovelExporter.vue` | 补全 `safeGetLocalStorage` / `safeSetJsonLocalStorage` / `safeParseJson` 的 import；`JSON.parse` → `safeParseJson` 防止损坏数据崩溃 |
| `src/modes/StandardChatMode/index.vue` | 去掉 `messages` watcher 的 `deep: true`；`handleScroll` 加 100ms 节流 |
| `src/utils/chatStorage.js` | 补全 `safeGetLocalStorage` / `safeRemoveLocalStorage` 的 import |
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a62b128-1c52-4466-b9ff-d83c38f1327e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a62b128-1c52-4466-b9ff-d83c38f1327e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

