### PR TITLE
自动标题：更短截取且不再追加「...」

### DIFF
--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -1,3 +1,6 @@
 // 定义全局常量配置
 export const MAX_TITLE_LENGTH = 26;
 export const BRANCH_SUFFIX = '（分支）'; // 合并产生分歧时的分支后缀
+
+/** 首条用户消息生成自动标题时的最大字符数（String.length） */
+export const AUTO_TITLE_FROM_FIRST_MESSAGE_MAX_CHARS = 12;

--- a/src/modes/GameMode/index.vue
+++ b/src/modes/GameMode/index.vue
@@ -302,6 +302,7 @@ import EmptyState from '@/shared/components/EmptyState.vue';
 import MessageControls from '@/modes/StandardChatMode/components/MessageControls.vue';
 import { callAiModel } from '@/core/services/aiService';
 import { createUuid } from '@/utils/chatData';
+import { autoTitleFromFirstUserContent } from '@/utils/archive';
 import {
 	getAllGamePacks,
 	getGamePackById,
@@ -1057,7 +1058,7 @@ export default {
 				this.chat.messages = [...this.chat.messages];
 				this.$emit('update-chat');
 				if (this.chat.messages.length <= 3 && this.chat.title === '新对话') {
-					this.chat.title = userInput.substring(0, 20) + (userInput.length > 20 ? '...' : '');
+					this.chat.title = autoTitleFromFirstUserContent(userInput);
 					this.$emit('update-chat');
 				}
 			} catch (error) {

--- a/src/modes/StandardChatMode/index.vue
+++ b/src/modes/StandardChatMode/index.vue
@@ -156,6 +156,7 @@ import EmptyState from '@/shared/components/EmptyState.vue';
 import MessageControls from './components/MessageControls.vue';
 import { throttle } from '@/utils/throttleHelper';
 import { createUuid } from '@/utils/chatData';
+import { autoTitleFromFirstUserContent } from '@/utils/archive';
 import { callAiModel } from '@/core/services/aiService';
 
 export default {
@@ -484,12 +485,7 @@ export default {
 			}
 		},
 		generateChatTitle(firstMessage) {
-			// 自动生成对话标题
-			let title = firstMessage.substring(0, 20);
-			if (firstMessage.length > 20) {
-				title += '...';
-			}
-			this.chat.title = title;
+			this.chat.title = autoTitleFromFirstUserContent(firstMessage);
 			this.$emit('update-chat');
 		},
 		scrollByPercent(percent) {

--- a/src/utils/archive.js
+++ b/src/utils/archive.js
@@ -1,10 +1,26 @@
 // 归档（存档）相关的纯函数模块
 // 注意：不依赖 Vue 组件实例；所有输入输出均显式传入与返回
 
-import { MAX_TITLE_LENGTH, BRANCH_SUFFIX } from '@/config/constants.js'
+import { MAX_TITLE_LENGTH, BRANCH_SUFFIX, AUTO_TITLE_FROM_FIRST_MESSAGE_MAX_CHARS } from '@/config/constants.js'
 
 export function normalizeText(text) {
   return (text || '').trim()
+}
+
+const LEGACY_AUTO_TITLE_FROM_FIRST_MESSAGE_MAX_CHARS = 20
+
+export function autoTitleFromFirstUserContent(rawContent) {
+  const text = normalizeText(rawContent || '')
+  if (!text) return '新对话'
+  const max = AUTO_TITLE_FROM_FIRST_MESSAGE_MAX_CHARS
+  return text.length > max ? text.slice(0, max) : text
+}
+
+function legacyAutoTitleFromFirstUserContent(rawContent) {
+  const text = normalizeText(rawContent || '')
+  if (!text) return '新对话'
+  const max = LEGACY_AUTO_TITLE_FROM_FIRST_MESSAGE_MAX_CHARS
+  return text.length > max ? `${text.slice(0, max)}...` : text
 }
 
 export function getMessageKey(msg) {
@@ -103,17 +119,13 @@ export function mergeImportedChats(importedChats = [], existingChats = []) {
   if (!Array.isArray(existingChats)) return importedChats
 
   const normalizeTitle = (value) => (typeof value === 'string' ? value.trim() : '')
-  const getDefaultAutoTitle = (chat) => {
-    const messages = Array.isArray(chat?.messages) ? chat.messages : []
-    const firstUserMessage = messages.find(msg => msg?.role === 'user')
-    const firstContent = normalizeText(firstUserMessage?.content || '')
-    if (!firstContent) return '新对话'
-    return firstContent.length > 20 ? `${firstContent.slice(0, 20)}...` : firstContent
-  }
   const isManualTitle = (chat) => {
     const title = normalizeTitle(chat?.title)
     if (!title || title === '新对话') return false
-    return title !== getDefaultAutoTitle(chat)
+    const messages = Array.isArray(chat?.messages) ? chat.messages : []
+    const firstUserMessage = messages.find(msg => msg?.role === 'user')
+    const raw = firstUserMessage?.content || ''
+    return title !== autoTitleFromFirstUserContent(raw) && title !== legacyAutoTitleFromFirstUserContent(raw)
   }
   const pickMergedTitle = (existingChat, importedChat) => {
     const existingTitle = normalizeTitle(existingChat?.title)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更说明

- 首条用户消息生成对话标题时，最大长度由 20 字符改为 12 字符（`AUTO_TITLE_FROM_FIRST_MESSAGE_MAX_CHARS`），过长时直接截断，**不再**在末尾追加 `...`，避免分支标题再截断时叠出多余省略号、挤占 `MAX_TITLE_LENGTH` 显示预算。
- 逻辑集中在 `src/utils/archive.js` 的 `autoTitleFromFirstUserContent`，标准对话与游戏模式共用。
- 存档导入合并时：`isManualTitle` 同时认可旧规则（前 20 字 + `...`）与新规则，避免旧数据被误判为手动标题。

## 验证

- 本地执行 `npm install` 与 `npm run build` 通过。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f1da1cf2-b3d7-4997-883b-623caea30a87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f1da1cf2-b3d7-4997-883b-623caea30a87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

