### PR TITLE
fix: GitHub Pages 部署重复 artifact 与自定义域名

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,68 +1,78 @@
-# 工作流的名称
 name: Deploy to GitHub Pages
 
-# 触发工作流的事件
 on:
-  # 当推送到 main 分支时触发
   push:
     branches:
       - main
-  # 允许你手动在 Actions 标签页中触发此工作流
   workflow_dispatch:
 
-# 设置 GITHUB_TOKEN 的权限，以允许部署到 GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
 
-# 定义一个名为 "deploy" 的作业 (job)
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
 jobs:
-  deploy:
-    # 设置作业的环境，指定部署到的 GitHub Pages URL
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    # 指定运行此作业的虚拟机类型
+  build:
     runs-on: ubuntu-latest
-    
-    # 作业中的步骤
     steps:
-      # 第一步：检出你的仓库代码
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # 第二步：设置 Node.js 环境
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          # 指定要使用的 Node.js 版本
           node-version: 20
-          # 使用缓存来加速 npm install
-          cache: 'npm'
+          cache: npm
 
-      # 第三步：安装项目依赖
       - name: Install dependencies
         run: npm install
 
-      # 第四步：构建静态网站
       - name: Build static site
-        # 确保你的 package.json 中有 "build" 脚本
         run: npm run build
 
-      # 第五步：设置 GitHub Pages，准备上传产物
       - name: Setup Pages
         uses: actions/configure-pages@v5
 
-      # 第六步：将构建输出的文件夹打包为产物
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          # 指定要上传的文件夹路径
-          # 注意：请根据你项目的实际构建输出目录进行修改 (常见的有 dist, build, public 等)
-          path: './dist' 
+          path: ./dist
 
-      # 第七步：部署到 GitHub Pages
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+      actions: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Prune duplicate github-pages artifacts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ github.run_id }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          artifacts=$(gh api "/repos/$REPO/actions/runs/$RUN_ID/artifacts" \
+            --jq '[.artifacts[] | select(.name == "github-pages")] | sort_by(.created_at) | reverse')
+          count=$(echo "$artifacts" | jq 'length')
+          echo "Found $count github-pages artifact(s) in this run."
+          if [ "$count" -le 1 ]; then
+            exit 0
+          fi
+          echo "$artifacts" | jq -r '.[1:] | .[].id' | while read -r id; do
+            echo "Deleting duplicate artifact $id"
+            gh api -X DELETE "/repos/$REPO/actions/artifacts/$id"
+          done
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+ai.tobenot.top


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

部署失败报错：

```
Multiple artifacts named "github-pages" were unexpectedly found for this workflow run. Artifact count is 2.
```

这不是分支/域名配置错误，而是同一 workflow run 内出现了两个同名 `github-pages` artifact。常见原因包括：

- `upload-pages-artifact` 在网络抖动时重试导致重复上传（上游已知问题）
- 在 build 与 deploy 同处一个 job 时，重跑失败步骤会再次上传 artifact

## 修改

1. **拆分 build / deploy job**：build 负责构建并上传 artifact，deploy 只负责部署（GitHub 推荐结构）
2. **部署前清理重复 artifact**：保留最新一个，删除其余同名 artifact
3. **添加 concurrency**：避免并发部署互相干扰
4. **添加 `public/CNAME`**：值为 `ai.tobenot.top`，随 Vite 构建进入 `dist/`，保证自定义域名配置随 Actions 部署发布

## 部署说明（合并后请确认）

在仓库 **Settings → Pages** 中：

- **Source** 应选择 **GitHub Actions**（不是 `gh-pages` 分支）
- **Custom domain** 填 `ai.tobenot.top`

`vite.config.js` 中 `base: '/'` 对自定义域名是正确的，无需改成仓库子路径。

`npm run deploy`（`gh-pages` 包推送到 `gh-pages` 分支）与 Actions 部署是两套机制，建议只保留 Actions 这一套，避免混用。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33bdcbfe-e8c2-49c3-9465-3a3e150c01a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33bdcbfe-e8c2-49c3-9465-3a3e150c01a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

