### PR TITLE
fix: GPT-5/o 系列改用 max_completion_tokens 避免 400 错误

### DIFF
--- a/src/utils/providers/openaiCompatible.js
+++ b/src/utils/providers/openaiCompatible.js
@@ -1,4 +1,5 @@
 import { applyPromptCacheControl } from '@/utils/promptCache';
+import { buildOpenAiTokenLimitFields, usesMaxCompletionTokens } from '@/utils/tokenLimits.js';
 
 export async function callModelOpenAICompatible({ apiUrl, apiKey, model, messages, temperature = 0.7, maxTokens = 4096, signal, onChunk, featurePassword, isBackendProxy, geminiReasoningEffort, stream = true, extraBody = {}, promptCacheTtl }) {
 
@@ -17,9 +18,15 @@ export async function callModelOpenAICompatible({ apiUrl, apiKey, model, message
 		messages: sanitizedMessages,
 		stream,
 		temperature,
-		max_tokens: maxTokens,
-		...extraBody
+		...extraBody,
+		...buildOpenAiTokenLimitFields(model, maxTokens)
 	};
+
+	if (usesMaxCompletionTokens(model)) {
+		delete requestBody.max_tokens;
+	} else {
+		delete requestBody.max_completion_tokens;
+	}
 
 	if (model && model.includes('gemini') && geminiReasoningEffort && geminiReasoningEffort !== 'off') {
 		requestBody.reasoning = {

--- a/src/utils/tokenLimits.js
+++ b/src/utils/tokenLimits.js
@@ -13,3 +13,25 @@ export function normalizeMaxTokens(value, fallback = DEFAULT_MAX_TOKENS) {
 
 	return Math.floor(numericValue);
 }
+
+export function getBaseModelName(model) {
+	if (typeof model !== 'string' || !model) return '';
+	return model.toLowerCase().split('/').pop() || '';
+}
+
+export function usesMaxCompletionTokens(model) {
+	const base = getBaseModelName(model);
+	if (!base) return false;
+	if (/^gpt-5(?:[\-.]|$)/.test(base)) return true;
+	if (/^gpt-4\.1(?:[\-.]|$)/.test(base)) return true;
+	if (/^o(?:1|3|4)(?:$|[-.])/.test(base)) return true;
+	return false;
+}
+
+export function buildOpenAiTokenLimitFields(model, maxTokens, fallback = DEFAULT_MAX_TOKENS) {
+	const safeMaxTokens = normalizeMaxTokens(maxTokens, fallback);
+	if (usesMaxCompletionTokens(model)) {
+		return { max_completion_tokens: safeMaxTokens };
+	}
+	return { max_tokens: safeMaxTokens };
+}

--- a/tests/token-limits.test.mjs
+++ b/tests/token-limits.test.mjs
@@ -1,0 +1,63 @@
+import {
+	buildOpenAiTokenLimitFields,
+	getBaseModelName,
+	usesMaxCompletionTokens
+} from '../src/utils/tokenLimits.js';
+
+function assert(condition, message) {
+	if (!condition) throw new Error(message);
+}
+
+function testModelDetection() {
+	const cases = [
+		['openai/gpt-5.4', true],
+		['gpt-5.4-pro', true],
+		['gpt-5.3-codex', true],
+		['gpt-4.1-mini', true],
+		['o3-mini', true],
+		['o1-preview', true],
+		['o4-mini', true],
+		['gpt-4o', false],
+		['gpt-4o-mini', false],
+		['claude-sonnet-4-6', false],
+		['gemini-2.5-flash', false]
+	];
+
+	for (const [model, expected] of cases) {
+		assert(
+			usesMaxCompletionTokens(model) === expected,
+			`${model}: expected ${expected}, got ${usesMaxCompletionTokens(model)}`
+		);
+		assert(
+			getBaseModelName(model) === model.toLowerCase().split('/').pop(),
+			`${model}: base model name mismatch`
+		);
+	}
+}
+
+function testTokenLimitFields() {
+	assert(
+		buildOpenAiTokenLimitFields('gpt-5.4', 4096).max_completion_tokens === 4096,
+		'gpt-5.4 should use max_completion_tokens'
+	);
+	assert(
+		buildOpenAiTokenLimitFields('gpt-5.4', 4096).max_tokens === undefined,
+		'gpt-5.4 should not include max_tokens'
+	);
+	assert(
+		buildOpenAiTokenLimitFields('gpt-4o', 4096).max_tokens === 4096,
+		'gpt-4o should use max_tokens'
+	);
+	assert(
+		buildOpenAiTokenLimitFields('gpt-4o', 4096).max_completion_tokens === undefined,
+		'gpt-4o should not include max_completion_tokens'
+	);
+	assert(
+		buildOpenAiTokenLimitFields('gpt-5.4', 0).max_completion_tokens >= 16,
+		'invalid maxTokens should fall back to a safe minimum'
+	);
+}
+
+testModelDetection();
+testTokenLimitFields();
+console.log('token-limits tests passed');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

调用 GPT-5 / o 系列等模型时，上游返回：

```
400 - Invalid 'max_completion_tokens': integer below minimum value. Expected a value >= 1, but got 0 instead.
```

## 原因

OpenAI 新版模型（`gpt-5.x`、`gpt-4.1`、`o1/o3/o4`）在 Chat Completions API 中不再接受 `max_tokens`，需要改用 `max_completion_tokens`。

项目此前始终发送 `max_tokens`，部分上游/中转会把该参数映射为 `max_completion_tokens=0`，从而触发 400 校验失败。

## 修复

- 在 `tokenLimits.js` 增加模型识别逻辑，判断是否需要 `max_completion_tokens`
- 在 `openaiCompatible.js` 中按模型选择正确参数名，并移除冲突字段，避免 `extraBody` 覆盖为 0
- 新增 `tests/token-limits.test.mjs` 覆盖模型识别与请求体字段构造

## 测试

```bash
node tests/token-limits.test.mjs
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0bd6d0d7-0301-47aa-b0d2-4030517d1826"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0bd6d0d7-0301-47aa-b0d2-4030517d1826"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

