### PR TITLE
feat: 消息底部显示 API 输入与缓存 token

### DIFF
--- a/src/modes/StandardChatMode/index.vue
+++ b/src/modes/StandardChatMode/index.vue
@@ -108,7 +108,12 @@
 					</template>
 				</MessageBubble>
 				<div class="mt-1 text-sm text-gray-400 px-2">
-					约 {{ messageTokenStats[index]?.messageTokens || 0 }} tokens，累计 {{ messageTokenStats[index]?.cumulativeTokens || 0 }} tokens，{{ formatMessageTime(msg) }}
+					<div v-if="msg.usage">
+						输入 {{ msg.usage.inputTokens }}（缓存 {{ msg.usage.cacheReadTokens }}）
+					</div>
+					<div>
+						约 {{ messageTokenStats[index]?.messageTokens || 0 }} tokens，累计 {{ messageTokenStats[index]?.cumulativeTokens || 0 }} tokens，{{ formatMessageTime(msg) }}
+					</div>
 				</div>
 				<div
 					v-if="showTitleReminderForMessage(msg, index)"
@@ -377,7 +382,8 @@ export default {
 				reasoning_content: '',
 				isReasoningCollapsed: this.config.defaultHideReasoning || false,
 				createdAt: new Date().toISOString(),
-				createdAtMs: Date.now()
+				createdAtMs: Date.now(),
+				usage: null
 			};
 			
 			this.chat.messages.push(assistantMessage);
@@ -393,12 +399,14 @@ export default {
 				// 缓冲变量
 				let pendingContent = '';
 				let pendingReasoning = '';
+				let pendingUsage = null;
 				
 				// 创建节流更新函数
 				// UI更新频率：1000ms (1fps) - 根据用户要求降低频率
 				const throttledUIUpdate = throttle(() => {
 					if (pendingContent) assistantMessage.content = pendingContent;
 					if (pendingReasoning) assistantMessage.reasoning_content = pendingReasoning;
+					if (pendingUsage) assistantMessage.usage = pendingUsage;
 					
 					// 强制更新视图
 					this.chat.messages = [...this.chat.messages];
@@ -415,7 +423,7 @@ export default {
 				}, 2000);
 				
 				// 调用AI
-				await callAiModel({
+				const aiResult = await callAiModel({
 					provider: this.config.provider,
 					apiUrl: effectiveApiUrl,
 					apiKey: this.config.apiKey,
@@ -442,6 +450,9 @@ export default {
 						if (chunk.reasoning_content !== undefined) {
 							pendingReasoning = chunk.reasoning_content;
 						}
+						if (chunk.usage) {
+							pendingUsage = chunk.usage;
+						}
 
 						// 触发节流更新
 						throttledUIUpdate();
@@ -452,6 +463,8 @@ export default {
 				// 确保最后的内容被更新
 				if (pendingContent) assistantMessage.content = pendingContent;
 				if (pendingReasoning) assistantMessage.reasoning_content = pendingReasoning;
+				if (pendingUsage) assistantMessage.usage = pendingUsage;
+				if (aiResult?.usage) assistantMessage.usage = aiResult.usage;
 				this.chat.messages = [...this.chat.messages];
 				this.$emit('update-chat');
 

--- a/src/utils/providers/anthropic.js
+++ b/src/utils/providers/anthropic.js
@@ -1,4 +1,5 @@
 import { applyPromptCacheControl } from '@/utils/promptCache';
+import { normalizeAnthropicUsage } from '@/utils/tokenUsage.js';
 
 /**
  * Anthropic 原生 /v1/messages 调用
@@ -198,7 +199,14 @@ export async function callModelAnthropicNative({ apiUrl, apiKey, model, messages
 		reasoning_content: '',
 		timestamp: new Date().toISOString(),
 		images: [],
-		usage: null // 缓存计数：{ input_tokens, output_tokens, cache_creation_input_tokens, cache_read_input_tokens }
+		usage: null // 归一化后：{ inputTokens, outputTokens, cacheReadTokens, totalTokens, source }
+	};
+
+	let rawUsage = null;
+	const setUsageFromRaw = (partial) => {
+		if (!partial || typeof partial !== 'object') return;
+		rawUsage = { ...(rawUsage || {}), ...partial };
+		newMessage.usage = normalizeAnthropicUsage(rawUsage);
 	};
 
 	// 非流式
@@ -218,9 +226,9 @@ export async function callModelAnthropicNative({ apiUrl, apiKey, model, messages
 			}
 		}
 		if (data.usage) {
-			newMessage.usage = data.usage;
 			console.log('[DEBUG] Anthropic native usage:', data.usage);
-			logCacheTelemetry(data.usage);
+			setUsageFromRaw(data.usage);
+			logCacheTelemetry(rawUsage);
 		}
 		return newMessage;
 	}
@@ -244,7 +252,7 @@ export async function callModelAnthropicNative({ apiUrl, apiKey, model, messages
 			if (eventType === 'message_start') {
 				const u = parsed.message?.usage;
 				if (u) {
-					newMessage.usage = { ...u };
+					setUsageFromRaw(u);
 				}
 			} else if (eventType === 'content_block_delta') {
 				const delta = parsed.delta;
@@ -260,7 +268,7 @@ export async function callModelAnthropicNative({ apiUrl, apiKey, model, messages
 			} else if (eventType === 'message_delta') {
 				// 增量补全 output_tokens 等
 				if (parsed.usage) {
-					newMessage.usage = { ...(newMessage.usage || {}), ...parsed.usage };
+					setUsageFromRaw(parsed.usage);
 				}
 			}
 			// message_stop / ping / content_block_start / content_block_stop：无需处理
@@ -308,7 +316,7 @@ export async function callModelAnthropicNative({ apiUrl, apiKey, model, messages
 
 	if (newMessage.usage) {
 		console.log('[DEBUG] Anthropic native final usage:', newMessage.usage);
-		logCacheTelemetry(newMessage.usage);
+		logCacheTelemetry(rawUsage);
 	} else {
 		console.warn('[DEBUG] Anthropic native: 未收到 usage（可能中转未回传）');
 	}

--- a/src/utils/providers/openaiCompatible.js
+++ b/src/utils/providers/openaiCompatible.js
@@ -1,5 +1,6 @@
 import { applyPromptCacheControl } from '@/utils/promptCache';
 import { buildOpenAiTokenLimitFields, usesMaxCompletionTokens } from '@/utils/tokenLimits.js';
+import { normalizeOpenAiUsage } from '@/utils/tokenUsage.js';
 
 export async function callModelOpenAICompatible({ apiUrl, apiKey, model, messages, temperature = 0.7, maxTokens = 4096, signal, onChunk, featurePassword, isBackendProxy, geminiReasoningEffort, stream = true, extraBody = {}, promptCacheTtl }) {
 
@@ -21,6 +22,14 @@ export async function callModelOpenAICompatible({ apiUrl, apiKey, model, message
 		...extraBody,
 		...buildOpenAiTokenLimitFields(model, maxTokens)
 	};
+
+	// 流式默认不回 usage；需要显式打开才能拿到 cached_tokens
+	if (stream) {
+		requestBody.stream_options = {
+			...(requestBody.stream_options || {}),
+			include_usage: true
+		};
+	}
 
 	if (usesMaxCompletionTokens(model)) {
 		delete requestBody.max_tokens;
@@ -72,7 +81,8 @@ export async function callModelOpenAICompatible({ apiUrl, apiKey, model, message
 		content: '',
 		reasoning_content: '',
 		timestamp: new Date().toISOString(),
-		images: [] // Support for images
+		images: [], // Support for images
+		usage: null
 	};
 
 	if (!stream) {
@@ -91,6 +101,7 @@ export async function callModelOpenAICompatible({ apiUrl, apiKey, model, message
 				newMessage.images = choice.message.images;
 			}
 		}
+		newMessage.usage = normalizeOpenAiUsage(data.usage);
 		return newMessage;
 	}
 
@@ -126,17 +137,22 @@ export async function callModelOpenAICompatible({ apiUrl, apiKey, model, message
 					throw new Error(`API错误: ${data.error.message || data.error.type || '未知错误'}`);
 				}
 
-				if (data.choices?.[0]?.delta?.reasoning_content !== undefined) {
-					newMessage.reasoning_content += data.choices[0].delta.reasoning_content || '';
-				} else if (data.choices?.[0]?.delta?.reasoning !== undefined) {
-					const reasoningText = data.choices[0].delta.reasoning || '';
+				// usage-only 末包：choices 可能为空数组，勿假设 choices[0] 必有
+				const delta = data.choices?.[0]?.delta;
+				if (delta?.reasoning_content !== undefined) {
+					newMessage.reasoning_content += delta.reasoning_content || '';
+				} else if (delta?.reasoning !== undefined) {
+					const reasoningText = delta.reasoning || '';
 					newMessage.reasoning_content += reasoningText.replace(/\\n/g, '\n');
 				}
-				if (data.choices?.[0]?.delta?.content !== undefined) {
-					newMessage.content += data.choices[0].delta.content || '';
+				if (delta?.content !== undefined) {
+					newMessage.content += delta.content || '';
 				}
 				if (typeof data.text === 'string') {
 					newMessage.content += data.text;
+				}
+				if (data.usage) {
+					newMessage.usage = normalizeOpenAiUsage(data.usage);
 				}
 				if (typeof onChunk === 'function') {
 					onChunk({ ...newMessage });

--- a/src/utils/tokenUsage.js
+++ b/src/utils/tokenUsage.js
@@ -1,0 +1,54 @@
+/**
+ * 把各家 API 的 usage 归一成 UI 用结构。
+ * @typedef {{ inputTokens: number, outputTokens: number, cacheReadTokens: number, totalTokens: number, source: 'anthropic' | 'openai' }} NormalizedUsage
+ */
+
+function toNonNegInt(value) {
+	const n = Number(value);
+	if (!Number.isFinite(n) || n < 0) return 0;
+	return Math.round(n);
+}
+
+/**
+ * Claude / Anthropic Messages API
+ * 总输入 = input_tokens + cache_read + cache_creation（input_tokens 不含缓存）
+ * @param {object|null|undefined} usage
+ * @returns {NormalizedUsage|null}
+ */
+export function normalizeAnthropicUsage(usage) {
+	if (!usage || typeof usage !== 'object') return null;
+	const cacheReadTokens = toNonNegInt(usage.cache_read_input_tokens);
+	const cacheWriteTokens = toNonNegInt(usage.cache_creation_input_tokens);
+	const uncachedInput = toNonNegInt(usage.input_tokens);
+	const outputTokens = toNonNegInt(usage.output_tokens);
+	const inputTokens = uncachedInput + cacheReadTokens + cacheWriteTokens;
+	return {
+		inputTokens,
+		outputTokens,
+		cacheReadTokens,
+		totalTokens: inputTokens + outputTokens,
+		source: 'anthropic'
+	};
+}
+
+/**
+ * OpenAI Chat Completions（及兼容端）
+ * prompt_tokens 已含 cached_tokens
+ * @param {object|null|undefined} usage
+ * @returns {NormalizedUsage|null}
+ */
+export function normalizeOpenAiUsage(usage) {
+	if (!usage || typeof usage !== 'object') return null;
+	const inputTokens = toNonNegInt(usage.prompt_tokens ?? usage.input_tokens);
+	const outputTokens = toNonNegInt(usage.completion_tokens ?? usage.output_tokens);
+	const details = usage.prompt_tokens_details || usage.input_tokens_details || {};
+	const cacheReadTokens = toNonNegInt(details.cached_tokens);
+	const totalTokens = toNonNegInt(usage.total_tokens) || inputTokens + outputTokens;
+	return {
+		inputTokens,
+		outputTokens,
+		cacheReadTokens,
+		totalTokens,
+		source: 'openai'
+	};
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 改动

标准聊天模式下，助手消息底部在保留「约 N tokens」本地估算的同时，新增 API 用量行：

`输入 10250（缓存 10000）`

- 有 `message.usage` 时显示；无则只显示原估算行
- 不展示 cache write

## 实现

- `tokenUsage.js`：归一化 Claude / OpenAI 的 usage 字段
  - Claude：`总输入 = input + cache_read + cache_creation`
  - OpenAI：`prompt_tokens` 已含缓存；`cached_tokens` 取自 `prompt_tokens_details`
- `openaiCompatible.js`：流式加 `stream_options.include_usage`，解析末包 usage
- `anthropic.js`：原有 usage 解析后归一化再下发
- `StandardChatMode`：持久化 `usage` 到消息，footer 两行展示

## 说明

中转若不回传 usage / cached_tokens，API 行不会出现，本地估算仍在。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ea9160d-7af7-45d3-af21-2d3dd7cc339b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ea9160d-7af7-45d3-af21-2d3dd7cc339b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

