### PR TITLE
feat: 添加清空全部对话功能

### DIFF
--- a/src/AppCore.vue
+++ b/src/AppCore.vue
@@ -179,6 +179,7 @@
 		@repair-chat-data="repairChatData"
 		@import-chat-archive="importChatArchive"
 		@archive-old-chats="archiveOldChats"
+		@clear-all-chats="clearAllChats"
 		@show-author-info="showAuthorInfo = true"
 		@show-changelog="showChangelog = true"
 		@force-migrate="forceMigrate"

--- a/src/appCore/methods/chatMethods.js
+++ b/src/appCore/methods/chatMethods.js
@@ -7,7 +7,8 @@ import { findLatestSnapshot, cloneData } from '@/utils/gamePackRuntime.js';
 import {
 	loadChatStorageData, saveChatStorageData, saveCurrentChatIdStorageData, clearChatStorageData,
 	archiveChatStorageData, archiveChatsStorageData, restoreChatFromArchiveStorageData,
-	deleteArchivedChatStorageData, loadArchiveIndex as loadArchiveIndexFromStorage
+	deleteArchivedChatStorageData, loadArchiveIndex as loadArchiveIndexFromStorage,
+	replaceAllStorageData
 } from '@/utils/chatStorage';
 
 export const chatMethods = {
@@ -212,6 +213,48 @@ export const chatMethods = {
 				this.stopCacheCountdown();
 			}
 			this.saveChatHistory();
+		}
+	},
+	/** 清空热区与归档区全部对话，保留 API 等配置；清空后新建一条空对话 */
+	async clearAllChats() {
+		const hotCount = Array.isArray(this.chatHistory) ? this.chatHistory.length : 0;
+		const archiveCount = Array.isArray(this.archiveIndex) ? this.archiveIndex.length : 0;
+		const total = hotCount + archiveCount;
+		if (total <= 0) {
+			this.$message({ message: '当前没有可清空的对话', type: 'info', duration: 2000 });
+			return;
+		}
+
+		console.log('[AppCore] 开始清空全部对话', { hotCount, archiveCount });
+		try {
+			await this.enqueueChatStorageTask(() => replaceAllStorageData({
+				hotHistory: [],
+				archivedChats: [],
+				archiveIndex: [],
+				currentChatId: null
+			}));
+
+			this.verifiedProtectedChatId = null;
+			this.unlockPasswordInput = '';
+			this.archiveIndex = [];
+			this.chatHistory = [];
+			this.currentChatId = null;
+			this.stopCacheCountdown();
+			this.createNewChat();
+
+			this.$message({
+				message: `已清空全部对话（热区 ${hotCount} 条 + 归档 ${archiveCount} 条）`,
+				type: 'success',
+				duration: 2500
+			});
+			console.log('[AppCore] 清空全部对话完成', { hotCount, archiveCount });
+		} catch (err) {
+			console.error('[AppCore] 清空全部对话失败', err);
+			this.$message({
+				message: '清空失败：' + (err.message || '未知错误'),
+				type: 'error',
+				duration: 3000
+			});
 		}
 	},
 	isChatProtected(chat) {

--- a/src/components/SettingsDrawer.vue
+++ b/src/components/SettingsDrawer.vue
@@ -212,6 +212,23 @@
 					</div>
 				</el-form-item>
 
+				<el-form-item label="清空对话">
+					<div style="display: flex; gap: 10px; flex-wrap: wrap; align-items: center;">
+						<el-button
+							size="small"
+							type="danger"
+							:disabled="chatCount + archiveCount <= 0"
+							@click="confirmClearAllChats"
+						>
+							清空全部对话
+						</el-button>
+						<span class="text-gray-500 text-sm">将删除热区 {{ chatCount }} 条与归档 {{ archiveCount }} 条</span>
+					</div>
+					<div class="mt-1 text-gray-600 text-sm">
+						不可恢复。请先用上方「导出完整备份」或「导出存档」留档。不会清除 API Key 等设置。
+					</div>
+				</el-form-item>
+
 				<el-form-item label="数据迁移">
 					<div style="display: flex; gap: 10px; flex-wrap: wrap; align-items: center;">
 						<el-button size="small" type="primary" @click="$emit('force-migrate')">
@@ -432,7 +449,7 @@ export default {
 		'export-chat-archive', 'export-current-chat-archive', 'export-recent-chat-archive',
 		'export-chat-titles', 'export-archived-chats', 'export-full-backup',
 		'repair-chat-data', 'import-chat-archive',
-		'archive-old-chats',
+		'archive-old-chats', 'clear-all-chats',
 		'show-author-info', 'show-changelog'
 	],
 	data() {
@@ -583,6 +600,42 @@ export default {
 				}
 			).then(() => {
 				this.$emit('archive-old-chats', 50);
+			}).catch(() => {});
+		},
+		confirmClearAllChats() {
+			const hotCount = this.chatCount;
+			const archiveCount = this.archiveCount;
+			const total = hotCount + archiveCount;
+			if (total <= 0) {
+				this.$message({ message: '当前没有可清空的对话', type: 'info', duration: 2000 });
+				return;
+			}
+
+			this.$confirm(
+				`将永久删除全部对话（热区 ${hotCount} 条 + 归档 ${archiveCount} 条），此操作不可恢复。建议先导出完整备份或导出存档。`,
+				'清空全部对话',
+				{
+					confirmButtonText: '继续清空',
+					cancelButtonText: '取消',
+					type: 'warning',
+					closeOnClickModal: false,
+					distinguishCancelAndClose: true
+				}
+			).then(() => this.$prompt(
+				'请输入「清空」以确认删除全部对话',
+				'二次确认',
+				{
+					confirmButtonText: '确认清空',
+					cancelButtonText: '取消',
+					inputPattern: /^清空$/,
+					inputErrorMessage: '请输入「清空」',
+					inputPlaceholder: '清空',
+					closeOnClickModal: false,
+					distinguishCancelAndClose: true,
+					type: 'error'
+				}
+			)).then(() => {
+				this.$emit('clear-all-chats');
 			}).catch(() => {});
 		},
 		emptyCustomPresetForm() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

个人向对话导出留档后，需要一次性清空全部已有对话，再开始工作向使用。原先只能逐条删除。

## 方案

在设置抽屉「对话归档」下方增加 **清空全部对话**（危险操作），而不是放在侧边栏：

1. 第一次确认：展示热区 / 归档数量，提示不可恢复，建议先导出
2. 第二次确认：必须输入「清空」才能继续
3. 执行时原子清空热区 + 归档冷区（`replaceAllStorageData`），保留 API Key 等设置
4. 清空后自动新建一条空对话

## 改动

- `SettingsDrawer.vue`：按钮与双重确认
- `chatMethods.js`：`clearAllChats`
- `AppCore.vue`：事件接线

## 使用建议

1. 先「导出完整备份」或「导出存档」
2. 再打开设置 → 清空全部对话
3. 按提示输入「清空」确认

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c8e3d81-b3f4-4cee-b796-cbe4edd2acca?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c8e3d81-b3f4-4cee-b796-cbe4edd2acca&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

