### PR TITLE
feat: API 格式显式切换与缓存不可用 UI

### DIFF
--- a/docs/api/API格式与缓存切换方案.md
+++ b/docs/api/API格式与缓存切换方案.md
@@ -1,7 +1,7 @@
 # API 格式显式切换与缓存可用性方案
 
-> 状态：方案（未实现）
-> 背景：当前已支持 Chat Completions 与 Anthropic Messages（Claude Code 同系）两条请求路径，但格式切换是隐式的，缓存可用性在 UI 上不可见。
+> 状态：已实现
+> 背景：当前已支持 Chat Completions 与 Anthropic Messages（Claude Code 同系）两条请求路径；本方案补齐显式格式切换与缓存不可用 UI。
 
 ---
 

--- a/docs/api/API格式与缓存切换方案.md
+++ b/docs/api/API格式与缓存切换方案.md
@@ -1,0 +1,264 @@
+# API 格式显式切换与缓存可用性方案
+
+> 状态：方案（未实现）
+> 背景：当前已支持 Chat Completions 与 Anthropic Messages（Claude Code 同系）两条请求路径，但格式切换是隐式的，缓存可用性在 UI 上不可见。
+
+---
+
+## 1. 现状
+
+### 1.1 两条 API 格式
+
+| 格式 | 端点 | 驱动 | 触发条件（现状） |
+|------|------|------|------------------|
+| Chat Completions | `/v1/chat/completions` | `openaiCompatible.js` | 默认路径；带前缀模型（如 `anthropic/claude-*`）；后端代理 |
+| Anthropic Messages（Claude Code 同系） | `/v1/messages` | `anthropic.js` | 裸名 `claude-*` 且非后端代理；失败则回退 Chat Completions |
+
+另有 Gemini 原生路径，与本文缓存议题无关。
+
+### 1.2 缓存与格式的关系
+
+Prompt Cache（`cache_control`）只在 Anthropic Messages 上可靠生效并回传 `cache_*_input_tokens`。Chat Completions 路径可注入标记，但多数中转会忽略，实测缓存写入常为 0。
+
+当前路由逻辑（`shouldUseAnthropicNative`）：
+
+- 裸 `claude-*` → 自动走 Anthropic Messages
+- `anthropic/claude-*` → 仍走 Chat Completions（交给中转自有缓存）
+- 后端代理 → 强制 Chat Completions（无 `/v1/messages`）
+
+### 1.3 UI 缺口
+
+- 设置抽屉 / 模型栏：**没有**「API 格式」开关，用户无法显式选择
+- 缓存控件（关 / 5m / 1h）始终可点，不区分当前路径是否真能缓存
+- 无「缓存不可用」态；仅有 tooltip 软提示与 DevTools 遥测
+
+消息上的灰色 **A** 徽章表示「自动断点」，不是 API 格式名。下文「Anthropic 格式」指 `/v1/messages` 路径。
+
+---
+
+## 2. 目标
+
+1. 在设置中可**显式切换** API 格式：Chat Completions ↔ Anthropic Messages
+2. **仅 Anthropic Messages 路径**开放 Prompt Cache 机制（写断点、计 TTL、倒计时）
+3. 选用 Claude 系列模型时，**自动切到 Anthropic Messages**，以便产生缓存
+4. 缓存不可用时，界面上的缓存设置呈现**明确不可用态**（禁用 + 原因）
+
+非目标：把 `protocol` 扩成用户可选第三种预设协议；不改 Gemini 路由；不引入 Claude Code CLI 协议。
+
+---
+
+## 3. 概念拆分
+
+把两层概念分开，避免和现有 `preset.protocol`（`openai` | `gemini`）纠缠：
+
+| 概念 | 含义 | 存哪 |
+|------|------|------|
+| `preset.protocol` | 预设通道：OpenAI 兼容底座 vs Gemini 原生 | 预设注册表（已有） |
+| `requestFormat` | 单次请求外壳：`chat_completions` \| `anthropic_messages` | 用户偏好 + 运行时推导 |
+
+`requestFormat` 只作用于「OpenAI 兼容底座」上的二次路由（老张、LMRouter、自定义中转等）。Gemini 预设不受此开关影响。
+
+命名建议（UI 文案）：
+
+- `Chat Completions`
+- `Anthropic Messages`（副文案：Claude Code 同系 / 可启用提示词缓存）
+
+内部枚举：`chat_completions` | `anthropic_messages` | `auto`（推荐默认）。
+
+---
+
+## 4. 路由规则
+
+### 4.1 有效格式 `resolveRequestFormat()`
+
+输入：`requestFormatPref`（用户偏好）、`model`、`isBackendProxy`、`preset.protocol`。
+
+```
+若 preset.protocol === 'gemini'        → 不走本开关（Gemini 驱动）
+若 isBackendProxy                      → chat_completions（硬约束）
+若 requestFormatPref === 'chat_completions'     → chat_completions
+若 requestFormatPref === 'anthropic_messages'   → anthropic_messages
+若 requestFormatPref === 'auto'（默认）:
+    若 isClaudeModel(model)            → anthropic_messages
+    否则                               → chat_completions
+```
+
+`isClaudeModel(model)` 建议：
+
+- 裸名 `/^claude-/i`
+- 或剥掉常见前缀后仍以 `claude-` 开头（如 `anthropic/claude-sonnet-4.5`）
+- 自动模式下对带前缀的 Claude：**仍切 Anthropic Messages**（与现状不同），以便缓存生效；若中转无 `/v1/messages`，沿用现有 404/405/5xx 回退
+
+### 4.2 与现状的差异
+
+| 场景 | 现状 | 方案后（auto） |
+|------|------|----------------|
+| 老张 + `claude-sonnet-4-…` | Anthropic Messages | 同左 |
+| OpenRouter + `anthropic/claude-…` | Chat Completions | **改为** Anthropic Messages（为缓存）；失败回退 |
+| 用户强制 Chat Completions + Claude | 无法强制 | 可强制；缓存标记为不可用 |
+| 用户强制 Anthropic Messages + 非 Claude | 无法强制 | 允许尝试（中转若支持）；缓存控件可用但提示「取决于上游」 |
+| 后端代理 + Claude | Chat Completions | 同左；缓存不可用 |
+
+### 4.3 缓存可用性 `isPromptCacheAvailable`
+
+```
+available =
+  !isBackendProxy
+  && requestFormatEffective === 'anthropic_messages'
+  && preset.protocol !== 'gemini'
+```
+
+可选加严：同时要求 `isClaudeModel(model)`。推荐**以格式为准**（与「只有 Anthropic 路径才能缓存」一致）；模型不匹配时用弱提示，不额外禁用。
+
+---
+
+## 5. UI 方案
+
+### 5.1 设置抽屉（右上角齿轮 → 设置）
+
+在「选择模型」附近新增一项：
+
+```
+API 格式
+  ○ 自动（推荐）
+  ○ Chat Completions
+  ○ Anthropic Messages（可启用提示词缓存）
+
+说明随选项变化：
+  自动：Claude 模型走 Anthropic Messages，其余走 Chat Completions
+  Chat Completions：始终 /v1/chat/completions；提示词缓存不可用
+  Anthropic Messages：始终 /v1/messages；需中转支持该端点
+```
+
+后端代理预设下：该项禁用，固定显示「Chat Completions（代理不支持 Messages 端点）」。
+
+Gemini 预设下：隐藏或禁用该项。
+
+### 5.2 模型栏缓存控件（`ModelSelector`）
+
+当 `!isPromptCacheAvailable`：
+
+1. 关 / 5m / 1h **整组 disabled**
+2. 旁注文案，例如：`缓存不可用 · 当前为 Chat Completions`
+3. tooltip 写清原因（见下表）
+4. 若用户此前选了 5m/1h，**保留偏好值**但运行时不注入 `cache_control`；恢复可用后无需重选
+
+| 原因码 | 界面文案 |
+|--------|----------|
+| `format_chat_completions` | 当前 API 格式为 Chat Completions，缓存仅在 Anthropic Messages 下可用 |
+| `backend_proxy` | 后端代理无 Messages 端点，缓存不可用 |
+| `gemini_protocol` | Gemini 通道不支持此缓存机制 |
+| （可用） | 现有说明保留 |
+
+### 5.3 消息侧缓存入口（金币 / A 徽章）
+
+不可用时：
+
+- 金币按钮 disabled，或点击后 dropdown 仅展示「缓存不可用：…」
+- 不展示自动 **A** 徽章（无自动断点）
+- 手动断点字段可保留在消息上，但发送时不注入
+
+### 5.4 可选：轻量状态条
+
+在模型栏右侧或缓存旁增加只读标签：`格式: 自动→Messages` / `格式: Completions`，降低「设了缓存却没生效」的困惑。非必须，可二期。
+
+---
+
+## 6. 数据与改动面
+
+### 6.1 持久化
+
+| Key | 值 | 说明 |
+|-----|-----|------|
+| `bs2_request_format` | `auto` \| `chat_completions` \| `anthropic_messages` | 全局偏好，默认 `auto` |
+
+不进预设，避免每个预设各记一份；若后续需要按预设记忆，再迁到 preset features。
+
+### 6.2 代码落点
+
+| 文件 | 改动 |
+|------|------|
+| 新建 `src/utils/requestFormat.js` | `isClaudeModel` / `resolveRequestFormat` / `isPromptCacheAvailable` / 原因码 |
+| `src/core/services/aiService.js` | 用 `resolveRequestFormat` 替换裸 `shouldUseAnthropicNative`；传入用户偏好 |
+| `src/appCore/methods/configMethods.js` + `AppCore.vue` / `store` | 读写 `requestFormat` |
+| `src/components/SettingsDrawer.vue` | API 格式单选项 |
+| `src/components/ModelSelector.vue` | 缓存控件 disabled + 原因 |
+| `MessageControls.vue` | 不可用态 |
+| 各 Mode `callAiModel` 调用处 | 传入 `requestFormat`；按可用性决定是否传有效 `promptCacheTtl` |
+| `promptCache.js` | 可选：入口处若 TTL 被上层清空则行为不变；不必感知格式 |
+
+### 6.3 调用链（改后）
+
+```
+Settings: requestFormatPref
+ModelSelector: 读 isPromptCacheAvailable → 启用/禁用缓存 UI
+Mode 发送:
+  format = resolveRequestFormat(...)
+  ttl = available ? promptCacheTtl : ''
+  callAiModel({ ..., requestFormat: format, promptCacheTtl: ttl })
+aiService:
+  anthropic_messages → anthropic.js（可回退）
+  chat_completions   → openaiCompatible.js
+```
+
+---
+
+## 7. 行为细则
+
+### 7.1 Claude 自动切换
+
+用户保持「自动」时：
+
+1. 选中任意 Claude 模型（含 `anthropic/` 前缀）→ 有效格式变为 Anthropic Messages
+2. 缓存控件变为可用（若非代理 / 非 Gemini）
+3. 切到非 Claude 模型 → 有效格式回到 Chat Completions，缓存控件禁用并展示原因
+
+用户显式选「Chat Completions」时：即使 Claude 也不自动切换；缓存保持不可用。
+
+用户显式选「Anthropic Messages」时：非 Claude 模型也走 Messages；中转不支持则按现有逻辑回退，并打状态变化日志（非 tick）。
+
+### 7.2 回退与日志
+
+保留 Anthropic 端点缺失时的回退。回退发生时：
+
+- 打一条状态变化日志（格式、status、是否回退）
+- 本次请求等价于无缓存；不在 UI 瞬时闪「不可用」（避免抖动）
+- 可选：会话级 `lastNativeEndpointFailed`，用于弱提示「当前中转可能不支持 Messages」
+
+### 7.3 与 OpenRouter 前缀模型
+
+现状故意让 `anthropic/` 走 Completions。方案在 **auto** 下改为走 Messages，以便统一缓存体验。风险：部分聚合商只有 Completions。回退机制覆盖该风险；若实测某预设从不支持 Messages，可在 preset `features.forceChatCompletions: true` 上打标（二期）。
+
+---
+
+## 8. 实施顺序
+
+1. **纯函数层**：`requestFormat.js` + 单测（模型判定、可用性、原因码）
+2. **路由接入**：`aiService` 吃偏好；Mode 传参；默认 `auto` 行为对齐 §4
+3. **设置 UI**：格式三选一
+4. **缓存不可用态**：ModelSelector + MessageControls
+5. **回退提示 / 状态标签**（可选）
+
+每步可独立合入；1–2 无 UI 也能改善 Claude 前缀模型的缓存命中。
+
+---
+
+## 9. 验收标准
+
+- [ ] 设置里可在三种格式间切换，刷新后偏好仍在
+- [ ] `auto` + Claude 模型 → 实际请求 `/v1/messages`（或回退有日志）
+- [ ] `auto` + 非 Claude → `/v1/chat/completions`
+- [ ] 强制 Completions 时，缓存 关/5m/1h 禁用，并显示「缓存不可用」及原因
+- [ ] 强制 Messages 且非代理时，缓存控件可用
+- [ ] 后端代理下格式项与缓存均不可用，文案正确
+- [ ] Gemini 预设不受格式开关干扰
+- [ ] 消息自动 **A** 徽章仅在缓存可用且全局 TTL 开启时出现
+
+---
+
+## 10. 开放问题（实现前确认）
+
+1. **「A 开头的 API」**若另有所指（例如仅某家中转、或仅指消息上的 A 徽章），需对齐后再改 `isPromptCacheAvailable` 条件。
+2. OpenRouter 类 `anthropic/` 前缀模型：auto 是否一律切 Messages（本方案默认是）。
+3. 格式偏好：全局一份，还是跟预设走。
+4. 缓存不可用时：仅禁用顶部控件，还是同时禁用消息金币菜单。

--- a/src/AppCore.vue
+++ b/src/AppCore.vue
@@ -70,6 +70,8 @@
 					:selected-model="model"
 					:models="models"
 					:prompt-cache-ttl="promptCacheTtl"
+					:cache-available="promptCacheAvailable"
+					:cache-unavailable-reason="promptCacheUnavailableReason"
 					@update:model="model = $event; saveModel()"
 					@update:prompt-cache-ttl="onPromptCacheTtlChange"
 				/>
@@ -155,6 +157,7 @@
 		:auto-collapse-reasoning="autoCollapseReasoning"
 		:models="models"
 		:gemini-reasoning-effort="geminiReasoningEffort"
+		:request-format="requestFormat"
 		:chat-count="chatHistory.length"
 		:archive-count="archiveIndex.length"
 		@switch-preset="switchPreset($event)"
@@ -167,6 +170,7 @@
 		@update:default-hide-reasoning="defaultHideReasoning = $event; saveDefaultHideReasoning()"
 		@update:auto-collapse-reasoning="autoCollapseReasoning = $event; saveAutoCollapseReasoning()"
 		@update:gemini-reasoning-effort="geminiReasoningEffort = $event; saveGeminiReasoningEffort()"
+		@update:request-format="onRequestFormatChange"
 		@create-custom-preset="onCreateCustomPreset($event)"
 		@update-custom-preset="onUpdateCustomPreset($event)"
 		@delete-custom-preset="onDeleteCustomPreset($event)"
@@ -244,6 +248,10 @@ import { safeGetLocalStorage, safeParseJson, safeRemoveLocalStorage, safeSetLoca
 import { DEFAULT_MAX_TOKENS, normalizeMaxTokens } from '@/utils/tokenLimits.js';
 import { mergeImportedChats, parseArchiveJson } from '@/utils/archive.js';
 import { normalizeAndRepairChats } from '@/utils/chatData';
+import {
+	getPromptCacheAvailability,
+	normalizeRequestFormatPref
+} from '@/utils/requestFormat.js';
 
 
 export default {
@@ -309,6 +317,7 @@ export default {
 			featurePassword: safeGetLocalStorage('bs2_feature_password', '') || '',
 			geminiReasoningEffort: safeGetLocalStorage('bs2_gemini_reasoning_effort', 'medium') || 'medium',
 			promptCacheTtl: safeGetLocalStorage('bs2_prompt_cache_ttl', '') || '',
+			requestFormat: normalizeRequestFormatPref(safeGetLocalStorage('bs2_request_format', 'auto')),
 
 			// 5分钟缓存倒计时（启用 5m 缓存并发送消息后启动）
 			cacheCountdownEndsAt: 0,
@@ -379,6 +388,26 @@ export default {
 		currentPreset() {
 			return getPresetById(this.activePresetId);
 		},
+		presetProtocol() {
+			return this.currentPreset?.protocol === 'gemini' ? 'gemini' : 'openai';
+		},
+		promptCacheAvailability() {
+			return getPromptCacheAvailability({
+				requestFormatPref: this.requestFormat,
+				model: this.model,
+				isBackendProxy: this.isBackendProxy,
+				protocol: this.presetProtocol
+			});
+		},
+		promptCacheAvailable() {
+			return this.promptCacheAvailability.available;
+		},
+		promptCacheUnavailableReason() {
+			return this.promptCacheAvailability.reason;
+		},
+		effectiveRequestFormat() {
+			return this.promptCacheAvailability.effectiveFormat;
+		},
 		modeConfig() {
 			return {
 				provider: this.provider,
@@ -391,6 +420,10 @@ export default {
 				featurePassword: this.featurePassword,
 				geminiReasoningEffort: this.geminiReasoningEffort,
 				promptCacheTtl: this.promptCacheTtl,
+				requestFormat: this.requestFormat,
+				promptCacheAvailable: this.promptCacheAvailable,
+				promptCacheUnavailableReason: this.promptCacheUnavailableReason,
+				effectiveRequestFormat: this.effectiveRequestFormat,
 				defaultHideReasoning: this.defaultHideReasoning,
 				autoCollapseReasoning: this.autoCollapseReasoning,
 				activePresetId: this.activePresetId,
@@ -401,7 +434,11 @@ export default {
 		}
 	},
 	watch: {
-		// Phase 2: 所有 API 状态由 preset 驱动，不再需要监听 apiUrl 变化
+		promptCacheAvailable(available) {
+			if (!available) {
+				this.stopCacheCountdown();
+			}
+		}
 	},
 	async created() {
 		console.log('[AppCore] 启动读档开始');

--- a/src/appCore/methods/configMethods.js
+++ b/src/appCore/methods/configMethods.js
@@ -25,6 +25,7 @@ import {
 import { fetchModelsFromServer } from '@/core/services/modelFetcher';
 import { safeGetLocalStorage, safeParseJson, safeSetLocalStorage } from '@/utils/localStorageSafe.js';
 import { normalizeMaxTokens } from '@/utils/tokenLimits.js';
+import { normalizeRequestFormatPref } from '@/utils/requestFormat.js';
 
 
 const DEFAULT_OPENAI_BASE_URL = 'https://api.siliconflow.cn/v1';
@@ -259,7 +260,7 @@ export const configMethods = {
 
 	/**
 	 * 提示词缓存开关：''=关闭 / '5m'=5分钟 / '1h'=1小时
-	 * 对所有预设生效（透传至请求体），仅支持缓存的端点（如 Claude 及透明转发中转站）会实际命中。
+	 * 仅 Anthropic Messages 路径实际注入；不可用时 UI 禁用，偏好值仍保留。
 	 */
 	onPromptCacheTtlChange(value) {
 		this.promptCacheTtl = value || '';
@@ -267,6 +268,23 @@ export const configMethods = {
 	},
 	savePromptCacheTtl() {
 		safeSetLocalStorage('bs2_prompt_cache_ttl', this.promptCacheTtl, '提示词缓存');
+	},
+
+	/**
+	 * API 格式偏好：auto | chat_completions | anthropic_messages
+	 */
+	onRequestFormatChange(value) {
+		const next = normalizeRequestFormatPref(value);
+		if (next === this.requestFormat) return;
+		console.log('[AppCore] Request format changed:', this.requestFormat, '→', next);
+		this.requestFormat = next;
+		safeSetLocalStorage('bs2_request_format', this.requestFormat, 'API 格式');
+		if (!this.promptCacheAvailable) {
+			this.stopCacheCountdown();
+		}
+	},
+	saveRequestFormat() {
+		safeSetLocalStorage('bs2_request_format', this.requestFormat, 'API 格式');
 	},
 
 

--- a/src/components/ModelSelector.vue
+++ b/src/components/ModelSelector.vue
@@ -27,16 +27,19 @@
 			<span class="model-label">缓存:</span>
 			<el-radio-group
 				:model-value="promptCacheTtl || ''"
+				:disabled="!cacheAvailable"
 				@update:model-value="handleCacheChange"
 				size="small"
 				class="cache-radio-group"
+				:class="{ 'is-unavailable': !cacheAvailable }"
 			>
 				<el-radio-button label="">关</el-radio-button>
 				<el-radio-button label="5m">5m</el-radio-button>
 				<el-radio-button label="1h">1h</el-radio-button>
 			</el-radio-group>
+			<span v-if="!cacheAvailable" class="cache-unavailable-label">{{ unavailableLabel }}</span>
 			<el-tooltip
-				content="提示词缓存：把重复发送的上下文缓存起来，命中后输入费用大幅降低（约 1 折）。此开关控制「自动补断点」的 TTL（关=不自动补；5m/1h=自动断点的有效期）。可在单条消息上用金币图标手动标记缓存点（自带 TTL，始终生效，与全局混用）。仅 Claude 等支持缓存的模型（含透明转发中转站）生效。"
+				:content="helpContent"
 				placement="bottom"
 			>
 				<el-icon class="cache-help-icon"><QuestionFilled /></el-icon>
@@ -47,6 +50,13 @@
 
 <script>
 import { QuestionFilled } from '@element-plus/icons-vue';
+import {
+	getCacheUnavailableLabel,
+	getCacheUnavailableTooltip
+} from '@/utils/requestFormat.js';
+
+const CACHE_HELP_AVAILABLE =
+	'提示词缓存：把重复发送的上下文缓存起来，命中后输入费用大幅降低（约 1 折）。此开关控制「自动补断点」的 TTL（关=不自动补；5m/1h=自动断点的有效期）。可在单条消息上用金币图标手动标记缓存点（自带 TTL，始终生效，与全局混用）。仅 Anthropic Messages 格式下可用。';
 
 export default {
 	name: 'ModelSelector',
@@ -54,14 +64,28 @@ export default {
 	props: {
 		selectedModel: { type: String, required: true },
 		models: { type: Array, required: true },
-		promptCacheTtl: { type: String, default: '' }
+		promptCacheTtl: { type: String, default: '' },
+		cacheAvailable: { type: Boolean, default: true },
+		cacheUnavailableReason: { type: String, default: null }
 	},
 	emits: ['update:model', 'update:prompt-cache-ttl'],
+	computed: {
+		unavailableLabel() {
+			return getCacheUnavailableLabel(this.cacheUnavailableReason);
+		},
+		helpContent() {
+			if (!this.cacheAvailable) {
+				return getCacheUnavailableTooltip(this.cacheUnavailableReason);
+			}
+			return CACHE_HELP_AVAILABLE;
+		}
+	},
 	methods: {
 		handleModelChange(value) {
 			this.$emit('update:model', value);
 		},
 		handleCacheChange(value) {
+			if (!this.cacheAvailable) return;
 			this.$emit('update:prompt-cache-ttl', value || '');
 		},
 		getModelDisplayName(model) {
@@ -120,6 +144,7 @@ export default {
 	border-radius: 8px;
 	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 	border: 1px solid #e5e7eb;
+	flex-wrap: wrap;
 }
 
 .model-label {
@@ -206,6 +231,18 @@ export default {
 	box-shadow: -1px 0 0 0 #805AD5;
 }
 
+.cache-radio-group.is-unavailable :deep(.el-radio-button__inner) {
+	opacity: 0.55;
+	cursor: not-allowed;
+}
+
+.cache-unavailable-label {
+	font-size: 12px;
+	color: #b45309;
+	white-space: nowrap;
+	flex-shrink: 0;
+}
+
 .cache-help-icon {
 	font-size: 14px;
 	color: #9ca3af;
@@ -235,6 +272,11 @@ export default {
 
 	.cache-radio-group :deep(.el-radio-button__inner) {
 		padding: 4px 8px;
+	}
+
+	.cache-unavailable-label {
+		white-space: normal;
+		line-height: 1.3;
 	}
 }
 

--- a/src/components/SettingsDrawer.vue
+++ b/src/components/SettingsDrawer.vue
@@ -138,6 +138,21 @@
 					</div>
 				</el-form-item>
 
+				<el-form-item v-if="showRequestFormat" label="API格式">
+					<el-radio-group
+						v-model="innerRequestFormat"
+						:disabled="isRequestFormatLocked"
+						size="small"
+					>
+						<el-radio-button label="auto">自动</el-radio-button>
+						<el-radio-button label="chat_completions">Chat Completions</el-radio-button>
+						<el-radio-button label="anthropic_messages">Anthropic Messages</el-radio-button>
+					</el-radio-group>
+					<div class="mt-1 text-gray-600 text-sm">
+						{{ requestFormatHint }}
+					</div>
+				</el-form-item>
+
 				<el-form-item label="Gemini思考">
 					<el-radio-group v-model="innerGeminiReasoningEffort">
 						<el-radio-button label="high">高</el-radio-button>
@@ -404,6 +419,7 @@ import {
 	normalizePresetFeatures
 } from '@/config/presets'
 import { fetchModelsFromServer } from '@/core/services/modelFetcher'
+import { normalizeRequestFormatPref, REQUEST_FORMAT } from '@/utils/requestFormat.js'
 import SecretTextInput from './SecretTextInput.vue'
 import AffiliateLink from './AffiliateLink.vue'
 
@@ -435,6 +451,7 @@ export default {
 		autoCollapseReasoning: { type: Boolean, default: false },
 		models: { type: Array, default: () => [] },
 		geminiReasoningEffort: { type: String, default: 'high' },
+		requestFormat: { type: String, default: 'auto' },
 		chatCount: { type: Number, default: 0 },
 		archiveCount: { type: Number, default: 0 }
 	},
@@ -444,6 +461,7 @@ export default {
 		'update:temperature', 'update:maxTokens', 'update:model',
 		'update:defaultHideReasoning', 'update:autoCollapseReasoning',
 		'update:geminiReasoningEffort',
+		'update:requestFormat',
 		'switch-preset', 'update:proxyBaseUrl',
 		'create-custom-preset', 'update-custom-preset', 'delete-custom-preset',
 		'export-chat-archive', 'export-current-chat-archive', 'export-recent-chat-archive',
@@ -500,6 +518,10 @@ export default {
 			get() { return this.geminiReasoningEffort },
 			set(v) { this.$emit('update:geminiReasoningEffort', v) }
 		},
+		innerRequestFormat: {
+			get() { return normalizeRequestFormatPref(this.requestFormat) },
+			set(v) { this.$emit('update:requestFormat', normalizeRequestFormatPref(v)) }
+		},
 		innerDefaultHideReasoning: {
 			get() { return this.defaultHideReasoning },
 			set(v) { this.$emit('update:defaultHideReasoning', v) }
@@ -507,6 +529,25 @@ export default {
 		innerAutoCollapseReasoning: {
 			get() { return this.autoCollapseReasoning },
 			set(v) { this.$emit('update:autoCollapseReasoning', v) }
+		},
+		showRequestFormat() {
+			return this.currentPreset?.protocol !== 'gemini';
+		},
+		isRequestFormatLocked() {
+			return this.isCurrentPresetProxy;
+		},
+		requestFormatHint() {
+			if (this.isRequestFormatLocked) {
+				return '后端代理固定使用 Chat Completions（无 /v1/messages），提示词缓存不可用。';
+			}
+			const pref = this.innerRequestFormat;
+			if (pref === REQUEST_FORMAT.CHAT_COMPLETIONS) {
+				return '始终走 /v1/chat/completions。提示词缓存不可用。';
+			}
+			if (pref === REQUEST_FORMAT.ANTHROPIC_MESSAGES) {
+				return '始终走 /v1/messages（Claude Code 同系）。需中转支持该端点；可启用提示词缓存。';
+			}
+			return '自动：Claude 模型走 Anthropic Messages（可启用缓存），其余走 Chat Completions。';
 		},
 		innerProxyBaseUrl: {
 			get() {

--- a/src/core/services/aiService.js
+++ b/src/core/services/aiService.js
@@ -9,11 +9,17 @@ import { callModelGemini } from '@/utils/providers/gemini';
 import { callModelAnthropicNative } from '@/utils/providers/anthropic';
 import { listModelsFromPresets } from '@/config/presets';
 import { normalizeMaxTokens } from '@/utils/tokenLimits.js';
+import {
+	REQUEST_FORMAT,
+	getPromptCacheAvailability,
+	normalizeRequestFormatPref,
+	resolveRequestFormat,
+	stripCacheBreakpoints
+} from '@/utils/requestFormat.js';
 
 /**
  * 根据模型名称推断提供商
  */
-
 function getProviderByModelName(model) {
 	if (typeof model !== 'string' || !model) return null;
 	if (model.startsWith('gemini-')) return 'gemini';
@@ -21,24 +27,8 @@ function getProviderByModelName(model) {
 	if (model.startsWith('deepseek/')) return 'openai_compatible';
 	if (model.startsWith('openrouter/')) return 'openai_compatible';
 	if (model.startsWith('lmrouter/')) return 'openai_compatible';
-	if (model.startsWith('anthropic/')) return 'openai_compatible'; // OpenRouter 等走自带缓存
+	if (model.startsWith('anthropic/')) return 'openai_compatible';
 	return null;
-}
-
-/**
- * 判定是否应走 Anthropic 原生 /v1/messages 端点
- *
- * 触发条件：裸 claude-* 模型名（无 anthropic/ 等前缀）。原生端点才能让 prompt
- * caching 真正生效并回传 cache_*_input_tokens（OpenAI 兼容端点实测缓存写入恒为 0）。
- * 带 provider 前缀的（anthropic/claude-...）由对应中转自行处理，仍走 openai_compatible。
- *
- * 安全兜底：若原生端点不存在（404/405 等），上层 callAiModel 会自动回退到
- * OpenAI 兼容路径，不影响原有可用性。
- */
-function shouldUseAnthropicNative(model) {
-	if (typeof model !== 'string' || !model) return false;
-	if (model.includes('/')) return false; // 带前缀的交给中转
-	return /^claude-/i.test(model);
 }
 
 /**
@@ -56,7 +46,7 @@ function normalizeApiUrl(apiUrl) {
 
 /**
  * 确保API URL包含completions端点
- * 
+ *
  * Phase 1A: 现在 apiUrlOptions 存储的是 baseUrl 格式（如 https://api.siliconflow.cn/v1），
  * 此函数需要正确处理这种输入，在发送请求前拼接完整端点。
  */
@@ -64,12 +54,12 @@ function ensureCompletionsEndpoint(apiUrl) {
 	if (!apiUrl) return apiUrl;
 	const url = String(apiUrl).trim();
 	if (!url) return url;
-	
+
 	// 保留显式的流式端点（后端代理路径）
 	if (url.includes('/stream')) {
 		return url;
 	}
-	
+
 	// 如果URL已经包含标准completions端点，原样返回
 	if (url.includes('/chat/completions')) {
 		return url;
@@ -85,15 +75,15 @@ function ensureCompletionsEndpoint(apiUrl) {
 		} catch (_) {}
 		return '/api/v1/chat/completions';
 	}
-	
+
 	// 移除尾部斜杠
 	const cleanUrl = url.endsWith('/') ? url.slice(0, -1) : url;
-	
+
 	// 如果已经以版本路径结尾（如 /v1、/v3、/v1beta），直接追加 /chat/completions
 	if (/\/v\d+(?:beta)?$/i.test(cleanUrl)) {
 		return cleanUrl + '/chat/completions';
 	}
-	
+
 	// 其他情况：追加 /v1/chat/completions
 	return cleanUrl + '/v1/chat/completions';
 }
@@ -116,20 +106,22 @@ export function getProviderByApiUrl(apiUrl) {
 }
 
 /**
+ * 按缓存可用性准备 messages 与 TTL
+ */
+function prepareCacheInputs(messages, promptCacheTtl, cacheAvailable) {
+	if (cacheAvailable) {
+		return { messages, promptCacheTtl: promptCacheTtl || '' };
+	}
+	return {
+		messages: stripCacheBreakpoints(messages),
+		promptCacheTtl: ''
+	};
+}
+
+/**
  * 核心AI调用方法
  * @param {Object} options - 配置选项
- * @param {string} options.provider - AI提供商
- * @param {string} options.apiUrl - API地址
- * @param {string} options.apiKey - API密钥
- * @param {string} options.model - 模型名称
- * @param {Array} options.messages - 消息数组
- * @param {number} options.temperature - 温度参数
- * @param {number} options.maxTokens - 最大token数
- * @param {AbortSignal} options.signal - 取消信号
- * @param {Function} options.onChunk - 流式返回回调
- * @param {string} options.featurePassword - 功能密码
- * @param {boolean} options.isBackendProxy - 是否使用后端代理
- * @param {string} options.geminiReasoningEffort - Gemini推理强度
+ * @param {string} [options.requestFormat] - API 格式偏好：auto | chat_completions | anthropic_messages
  */
 export async function callAiModel({
 	provider,
@@ -146,9 +138,11 @@ export async function callAiModel({
 	geminiReasoningEffort,
 	stream = true,
 	extraBody = {},
-	promptCacheTtl
+	promptCacheTtl,
+	requestFormat = REQUEST_FORMAT.AUTO
 }) {
 	const safeMaxTokens = normalizeMaxTokens(maxTokens, 4096);
+	const formatPref = normalizeRequestFormatPref(requestFormat);
 
 	console.log('[Core AI Service] callAiModel called:', {
 		provider,
@@ -163,13 +157,13 @@ export async function callAiModel({
 		stream,
 		extraBodyKeys: Object.keys(extraBody || {}),
 		hasResponseFormat: Boolean(extraBody?.response_format),
-		promptCacheTtl
-
+		promptCacheTtl,
+		requestFormat: formatPref
 	});
-	
+
 	const normalizedUrl = normalizeApiUrl(apiUrl);
 	const finalUrl = ensureCompletionsEndpoint(normalizedUrl);
-	
+
 	let effectiveProvider = provider;
 	let finalModel = model;
 
@@ -178,19 +172,38 @@ export async function callAiModel({
 	if (providerFromModel) {
 		effectiveProvider = providerFromModel;
 	}
-	
+
 	if (!effectiveProvider) {
 		effectiveProvider = getProviderByApiUrl(finalUrl);
 	}
-	
-	console.log('[Core AI Service] Final URL:', finalUrl, 'Effective provider:', effectiveProvider, 'Final model:', finalModel);
-	
+
+	const protocol = effectiveProvider === 'gemini' ? 'gemini' : 'openai';
+	const effectiveFormat = resolveRequestFormat({
+		requestFormatPref: formatPref,
+		model: finalModel,
+		isBackendProxy,
+		protocol
+	});
+	const cacheInfo = getPromptCacheAvailability({
+		requestFormatPref: formatPref,
+		model: finalModel,
+		isBackendProxy,
+		protocol
+	});
+	const cacheInputs = prepareCacheInputs(messages, promptCacheTtl, cacheInfo.available);
+
+	console.log('[Core AI Service] Final URL:', finalUrl,
+		'Effective provider:', effectiveProvider,
+		'Final model:', finalModel,
+		'Request format:', effectiveFormat,
+		'Cache available:', cacheInfo.available);
+
 	if (effectiveProvider === 'gemini') {
 		return callModelGemini({
 			apiUrl: finalUrl,
 			apiKey,
 			model: finalModel,
-			messages,
+			messages: cacheInputs.messages,
 			temperature,
 			maxTokens: safeMaxTokens,
 			signal,
@@ -198,21 +211,19 @@ export async function callAiModel({
 			featurePassword,
 			isBackendProxy: isBackendProxy,
 			geminiReasoningEffort,
-			promptCacheTtl
+			promptCacheTtl: cacheInputs.promptCacheTtl
 		});
 	}
 
-	// ── Anthropic 原生 /v1/messages（仅裸 claude-* 模型，且非后端代理）──
-	// 走原生端点才能让 prompt caching 生效并回传缓存计数。后端代理只暴露
-	// /chat/completions 式端点、无 /v1/messages，直接跳过避免无谓失败请求。
-	// 直连场景下若中转不存在该端点（404/405/5xx），自动回退 OpenAI 兼容路径。
-	if (shouldUseAnthropicNative(finalModel) && !isBackendProxy) {
-		// 传规范化后的 baseUrl，由 provider 内部转为 /v1/messages
+	// Anthropic Messages：走原生端点才能让 prompt caching 生效并回传缓存计数。
+	// 后端代理无 /v1/messages，resolveRequestFormat 已强制 chat_completions。
+	// 中转若无该端点（404/405/5xx），回退 OpenAI 兼容路径。
+	if (effectiveFormat === REQUEST_FORMAT.ANTHROPIC_MESSAGES && !isBackendProxy) {
 		const nativeArgs = {
 			apiUrl: normalizedUrl,
 			apiKey,
 			model: finalModel,
-			messages,
+			messages: cacheInputs.messages,
 			temperature,
 			maxTokens: safeMaxTokens,
 			signal,
@@ -221,19 +232,19 @@ export async function callAiModel({
 			isBackendProxy: isBackendProxy,
 			stream,
 			extraBody,
-			promptCacheTtl
+			promptCacheTtl: cacheInputs.promptCacheTtl
 		};
 		try {
-			console.log('[Core AI Service] Routing to Anthropic native for', finalModel);
+			console.log('[Core AI Service] Routing to Anthropic Messages for', finalModel,
+				'(pref:', formatPref + ')');
 			return await callModelAnthropicNative(nativeArgs);
 		} catch (err) {
-			// 仅当端点不存在类错误才回退；业务错误（鉴权 401、限流 429 等）直接抛出
 			const status = err?.status;
 			const isMissingEndpoint = err?.isAnthropicNativeError
 				&& (status === 404 || status === 405 || (status >= 500 && status < 600));
 			if (!isMissingEndpoint) throw err;
-			console.warn('[Core AI Service] Anthropic native endpoint unavailable ('
-				+ status + '), falling back to OpenAI-compatible:', err.message);
+			console.warn('[Core AI Service] Anthropic Messages endpoint unavailable ('
+				+ status + '), falling back to Chat Completions:', err.message);
 		}
 	}
 
@@ -241,18 +252,17 @@ export async function callAiModel({
 		apiUrl: finalUrl,
 		apiKey,
 		model: finalModel,
-		messages,
+		messages: cacheInputs.messages,
 		temperature,
 		maxTokens: safeMaxTokens,
 		signal,
 		onChunk,
 		featurePassword,
 		isBackendProxy: isBackendProxy,
-
 		geminiReasoningEffort,
 		stream,
 		extraBody,
-		promptCacheTtl
+		promptCacheTtl: cacheInputs.promptCacheTtl
 	});
 }
 
@@ -263,4 +273,3 @@ export async function callAiModel({
 export function listModelsByProvider(provider, isBackendProxy = false, apiUrl = '') {
 	return listModelsFromPresets(provider, isBackendProxy, apiUrl);
 }
-

--- a/src/modes/DrawMode/index.vue
+++ b/src/modes/DrawMode/index.vue
@@ -72,6 +72,9 @@
 							:index="index"
 							:is-last="index === messages.length - 1"
 							:is-typing="isTyping"
+							:cache-available="config.promptCacheAvailable !== false"
+							:cache-unavailable-reason="config.promptCacheUnavailableReason"
+							:prompt-cache-ttl="config.promptCacheTtl"
 							@copy="$emit('copy-message', msg.content)"
 							@edit="$emit('edit-message', index)"
 							@regenerate="$emit('regenerate-message')"
@@ -209,6 +212,7 @@ export default {
 		},
 		/** 当前生效的缓存 TTL：'5m' | '1h' | null（全局优先，否则取最后一条手动断点） */
 		activeCacheTtl() {
+			if (this.config.promptCacheAvailable === false) return null;
 			const global = this.config.promptCacheTtl;
 			if (global === '5m' || global === '1h') return global;
 			for (let i = this.messages.length - 1; i >= 0; i--) {
@@ -349,7 +353,8 @@ export default {
 					isBackendProxy: this.isBackendProxy,
 					stream: false,
 					extraBody: Object.keys(extraBody).length > 0 ? extraBody : undefined,
-					promptCacheTtl: this.config.promptCacheTtl
+					promptCacheTtl: this.config.promptCacheTtl,
+					requestFormat: this.config.requestFormat || 'auto'
 				});
 
 				console.log('[DrawMode] Result:', result);

--- a/src/modes/GameMode/index.vue
+++ b/src/modes/GameMode/index.vue
@@ -234,6 +234,9 @@
 									:index="index"
 									:is-last="index === messages.length - 1"
 									:is-typing="isTyping"
+									:cache-available="config.promptCacheAvailable !== false"
+									:cache-unavailable-reason="config.promptCacheUnavailableReason"
+									:prompt-cache-ttl="config.promptCacheTtl"
 									@copy="$emit('copy-message', msg.content)"
 									@edit="$emit('edit-message', index)"
 									@regenerate="$emit('regenerate-message')"
@@ -403,6 +406,7 @@ export default {
 		},
 		/** 当前生效的缓存 TTL：'5m' | '1h' | null（全局优先，否则取最后一条手动断点） */
 		activeCacheTtl() {
+			if (this.config.promptCacheAvailable === false) return null;
 			const global = this.config.promptCacheTtl;
 			if (global === '5m' || global === '1h') return global;
 			for (let i = this.messages.length - 1; i >= 0; i--) {
@@ -1159,7 +1163,8 @@ export default {
 				geminiReasoningEffort: this.config.geminiReasoningEffort,
 				stream: false,
 				extraBody,
-				promptCacheTtl: this.config.promptCacheTtl
+				promptCacheTtl: this.config.promptCacheTtl,
+				requestFormat: this.config.requestFormat || 'auto'
 			};
 			try {
 				return await callAiModel(requestOptions);

--- a/src/modes/StandardChatMode/components/MessageControls.vue
+++ b/src/modes/StandardChatMode/components/MessageControls.vue
@@ -45,10 +45,15 @@
 			<span class="cache-trigger" :aria-label="cacheAriaLabel">
 				<el-button
 					class="btn-cache"
-					:class="{ 'is-marked': !!cacheBadge, 'is-auto': isAuto }"
+					:class="{
+						'is-marked': !!cacheBadge && cacheAvailable,
+						'is-auto': isAuto,
+						'is-unavailable': !cacheAvailable
+					}"
+					:disabled="!cacheAvailable && !cacheBadge"
 				>
 					<el-icon style="font-size: 1.6rem;"><Coin /></el-icon>
-					<span v-if="cacheBadge" class="cache-badge">{{ cacheBadge }}</span>
+					<span v-if="cacheBadge && cacheAvailable" class="cache-badge">{{ cacheBadge }}</span>
 					<span v-else-if="isAuto" class="cache-badge auto">A</span>
 				</el-button>
 			</span>
@@ -58,20 +63,30 @@
 					<el-dropdown-item disabled class="cache-status-line">
 						{{ statusLine }}
 					</el-dropdown-item>
-					<!-- 手动点作用说明：告知用户手动点会缓存「到这条为止」的整段 -->
-					<el-dropdown-item v-if="!cacheBadge" disabled class="cache-hint-line">
-						手动点 = 缓存「到这条为止」的整段（覆盖长内容终点）
-					</el-dropdown-item>
-					<el-dropdown-item divided command="5m" :disabled="cacheBadge === '5m'">
-						手动覆盖 · 5 分钟
-					</el-dropdown-item>
-					<el-dropdown-item command="1h" :disabled="cacheBadge === '1h'">
-						手动覆盖 · 1 小时
-					</el-dropdown-item>
-					<!-- 手动点删除后的去向取决于该位置是否本就是自动点 -->
-					<el-dropdown-item v-if="cacheBadge" divided command="auto">
-						{{ wouldBeAuto ? '恢复自动' : '取消缓存' }}
-					</el-dropdown-item>
+					<template v-if="!cacheAvailable">
+						<el-dropdown-item disabled class="cache-hint-line">
+							{{ unavailableHint }}
+						</el-dropdown-item>
+						<el-dropdown-item v-if="cacheBadge" divided command="auto">
+							清除已保存的手动点
+						</el-dropdown-item>
+					</template>
+					<template v-else>
+						<!-- 手动点作用说明：告知用户手动点会缓存「到这条为止」的整段 -->
+						<el-dropdown-item v-if="!cacheBadge" disabled class="cache-hint-line">
+							手动点 = 缓存「到这条为止」的整段（覆盖长内容终点）
+						</el-dropdown-item>
+						<el-dropdown-item divided command="5m" :disabled="cacheBadge === '5m'">
+							手动覆盖 · 5 分钟
+						</el-dropdown-item>
+						<el-dropdown-item command="1h" :disabled="cacheBadge === '1h'">
+							手动覆盖 · 1 小时
+						</el-dropdown-item>
+						<!-- 手动点删除后的去向取决于该位置是否本就是自动点 -->
+						<el-dropdown-item v-if="cacheBadge" divided command="auto">
+							{{ wouldBeAuto ? '恢复自动' : '取消缓存' }}
+						</el-dropdown-item>
+					</template>
 				</el-dropdown-menu>
 			</template>
 		</el-dropdown>
@@ -87,6 +102,10 @@
 <script>
 import { CopyDocument, Edit, Refresh, Delete, Share, ArrowUp, ArrowDown, Coin } from '@element-plus/icons-vue';
 import { isAutoBreakpoint, getAutoRole } from '@/utils/promptCache';
+import {
+	getCacheUnavailableLabel,
+	getCacheUnavailableTooltip
+} from '@/utils/requestFormat.js';
 
 export default {
 	name: 'MessageControls',
@@ -120,6 +139,18 @@ export default {
 		isTyping: {
 			type: Boolean,
 			default: false
+		},
+		cacheAvailable: {
+			type: Boolean,
+			default: true
+		},
+		cacheUnavailableReason: {
+			type: String,
+			default: null
+		},
+		promptCacheTtl: {
+			type: String,
+			default: ''
 		}
 	},
 	emits: ['copy', 'edit', 'regenerate', 'delete', 'toggle-reasoning', 'fork', 'toggle-collapse', 'cache-breakpoint'],
@@ -128,7 +159,11 @@ export default {
 			const v = this.message?.cacheBreakpoint;
 			return v === '5m' || v === '1h' ? v : '';
 		},
+		globalCacheOn() {
+			return this.promptCacheTtl === '5m' || this.promptCacheTtl === '1h';
+		},
 		isAuto() {
+			if (!this.cacheAvailable || !this.globalCacheOn) return false;
 			// 该消息是否会被自动标记为缓存断点（手动标记优先，不显示自动样式）
 			return !this.cacheBadge && isAutoBreakpoint(this.messages, this.index);
 		},
@@ -144,12 +179,19 @@ export default {
 			return isAutoBreakpoint(cleared, this.index);
 		},
 		cacheAriaLabel() {
+			if (!this.cacheAvailable) return getCacheUnavailableLabel(this.cacheUnavailableReason);
 			if (this.cacheBadge) return `缓存点：${this.cacheBadge === '5m' ? '5 分钟' : '1 小时'}（手动）`;
 			if (this.isAuto) return '自动缓存点，点击可手动覆盖';
 			return '标记为缓存点';
 		},
+		unavailableHint() {
+			return getCacheUnavailableTooltip(this.cacheUnavailableReason);
+		},
 		// 下拉菜单首行：当前状态说明（手机无 tooltip 也能看到）
 		statusLine() {
+			if (!this.cacheAvailable) {
+				return getCacheUnavailableLabel(this.cacheUnavailableReason);
+			}
 			if (this.cacheBadge) {
 				return `当前：手动 · ${this.cacheBadge === '5m' ? '5 分钟' : '1 小时'}`;
 			}
@@ -167,6 +209,13 @@ export default {
 	},
 	methods: {
 		onCacheCommand(command) {
+			// 不可用时仅允许清除残留手动点
+			if (!this.cacheAvailable) {
+				if (command === 'auto') {
+					this.$emit('cache-breakpoint', null);
+				}
+				return;
+			}
 			// 'auto' = 恢复自动（删除手动标记，自动策略重新接管）
 			if (command === 'auto') {
 				this.$emit('cache-breakpoint', null);
@@ -198,6 +247,10 @@ export default {
 .btn-cache.is-auto {
 	color: #fff;
 	border-color: transparent;
+}
+
+.btn-cache.is-unavailable {
+	opacity: 0.45;
 }
 
 .cache-badge {

--- a/src/modes/StandardChatMode/index.vue
+++ b/src/modes/StandardChatMode/index.vue
@@ -96,6 +96,9 @@
 							:index="index"
 							:is-last="index === messages.length - 1"
 							:is-typing="isTyping"
+							:cache-available="config.promptCacheAvailable !== false"
+							:cache-unavailable-reason="config.promptCacheUnavailableReason"
+							:prompt-cache-ttl="config.promptCacheTtl"
 							@copy="$emit('copy-message', msg.content)"
 							@edit="$emit('edit-message', index)"
 							@regenerate="$emit('regenerate-message')"
@@ -238,6 +241,7 @@ export default {
 		},
 		/** 当前生效的缓存 TTL：'5m' | '1h' | null（全局优先，否则取最后一条手动断点） */
 		activeCacheTtl() {
+			if (this.config.promptCacheAvailable === false) return null;
 			const global = this.config.promptCacheTtl;
 			if (global === '5m' || global === '1h') return global;
 			for (let i = this.messages.length - 1; i >= 0; i--) {
@@ -436,6 +440,7 @@ export default {
 					isBackendProxy: this.isBackendProxy,
 					geminiReasoningEffort: this.config.geminiReasoningEffort,
 					promptCacheTtl: this.config.promptCacheTtl,
+					requestFormat: this.config.requestFormat || 'auto',
 					onChunk: (chunk) => {
 						// 首个 chunk = 服务端开始生成响应 ≈ 官方「response begins」，
 						// 此刻启动缓存倒计时，与 TTL 计时起点对齐。

--- a/src/utils/requestFormat.js
+++ b/src/utils/requestFormat.js
@@ -1,0 +1,175 @@
+/**
+ * 请求格式（Chat Completions / Anthropic Messages）与 Prompt Cache 可用性
+ *
+ * requestFormat 是 OpenAI 兼容底座上的二次路由，与 preset.protocol（openai|gemini）分开。
+ */
+
+export const REQUEST_FORMAT = {
+	AUTO: 'auto',
+	CHAT_COMPLETIONS: 'chat_completions',
+	ANTHROPIC_MESSAGES: 'anthropic_messages'
+};
+
+export const CACHE_UNAVAILABLE_REASON = {
+	FORMAT_CHAT_COMPLETIONS: 'format_chat_completions',
+	BACKEND_PROXY: 'backend_proxy',
+	GEMINI_PROTOCOL: 'gemini_protocol'
+};
+
+const VALID_PREFS = new Set([
+	REQUEST_FORMAT.AUTO,
+	REQUEST_FORMAT.CHAT_COMPLETIONS,
+	REQUEST_FORMAT.ANTHROPIC_MESSAGES
+]);
+
+/**
+ * @param {unknown} value
+ * @returns {'auto'|'chat_completions'|'anthropic_messages'}
+ */
+export function normalizeRequestFormatPref(value) {
+	const v = typeof value === 'string' ? value.trim() : '';
+	return VALID_PREFS.has(v) ? v : REQUEST_FORMAT.AUTO;
+}
+
+/**
+ * 判定是否为 Claude 系列模型（含 anthropic/claude-* 等前缀）
+ * @param {unknown} model
+ * @returns {boolean}
+ */
+export function isClaudeModel(model) {
+	if (typeof model !== 'string' || !model) return false;
+	const bare = model.includes('/') ? model.slice(model.lastIndexOf('/') + 1) : model;
+	return /^claude[-_]/i.test(bare);
+}
+
+/**
+ * 解析本次请求应使用的外壳格式
+ * Gemini 通道返回 null（由 gemini 驱动处理，不走本开关）
+ *
+ * @param {Object} options
+ * @param {string} [options.requestFormatPref]
+ * @param {string} [options.model]
+ * @param {boolean} [options.isBackendProxy]
+ * @param {string} [options.protocol] 'openai' | 'gemini'
+ * @returns {'chat_completions'|'anthropic_messages'|null}
+ */
+export function resolveRequestFormat({
+	requestFormatPref = REQUEST_FORMAT.AUTO,
+	model = '',
+	isBackendProxy = false,
+	protocol = 'openai'
+} = {}) {
+	if (protocol === 'gemini') return null;
+	if (isBackendProxy) return REQUEST_FORMAT.CHAT_COMPLETIONS;
+
+	const pref = normalizeRequestFormatPref(requestFormatPref);
+	if (pref === REQUEST_FORMAT.CHAT_COMPLETIONS) return REQUEST_FORMAT.CHAT_COMPLETIONS;
+	if (pref === REQUEST_FORMAT.ANTHROPIC_MESSAGES) return REQUEST_FORMAT.ANTHROPIC_MESSAGES;
+
+	return isClaudeModel(model)
+		? REQUEST_FORMAT.ANTHROPIC_MESSAGES
+		: REQUEST_FORMAT.CHAT_COMPLETIONS;
+}
+
+/**
+ * Prompt Cache 是否可用，及不可用原因
+ *
+ * @returns {{ available: boolean, reason: string|null, effectiveFormat: string|null }}
+ */
+export function getPromptCacheAvailability({
+	requestFormatPref = REQUEST_FORMAT.AUTO,
+	model = '',
+	isBackendProxy = false,
+	protocol = 'openai'
+} = {}) {
+	if (protocol === 'gemini') {
+		return {
+			available: false,
+			reason: CACHE_UNAVAILABLE_REASON.GEMINI_PROTOCOL,
+			effectiveFormat: null
+		};
+	}
+	if (isBackendProxy) {
+		return {
+			available: false,
+			reason: CACHE_UNAVAILABLE_REASON.BACKEND_PROXY,
+			effectiveFormat: REQUEST_FORMAT.CHAT_COMPLETIONS
+		};
+	}
+
+	const effectiveFormat = resolveRequestFormat({
+		requestFormatPref,
+		model,
+		isBackendProxy,
+		protocol
+	});
+
+	if (effectiveFormat !== REQUEST_FORMAT.ANTHROPIC_MESSAGES) {
+		return {
+			available: false,
+			reason: CACHE_UNAVAILABLE_REASON.FORMAT_CHAT_COMPLETIONS,
+			effectiveFormat
+		};
+	}
+
+	return {
+		available: true,
+		reason: null,
+		effectiveFormat
+	};
+}
+
+export function isPromptCacheAvailable(options) {
+	return getPromptCacheAvailability(options).available;
+}
+
+/**
+ * 缓存不可用时的短文案（模型栏旁注）
+ * @param {string|null} reason
+ * @returns {string}
+ */
+export function getCacheUnavailableLabel(reason) {
+	switch (reason) {
+		case CACHE_UNAVAILABLE_REASON.FORMAT_CHAT_COMPLETIONS:
+			return '缓存不可用 · 当前为 Chat Completions';
+		case CACHE_UNAVAILABLE_REASON.BACKEND_PROXY:
+			return '缓存不可用 · 代理无 Messages 端点';
+		case CACHE_UNAVAILABLE_REASON.GEMINI_PROTOCOL:
+			return '缓存不可用 · Gemini 通道不支持';
+		default:
+			return '缓存不可用';
+	}
+}
+
+/**
+ * 缓存不可用时的详细说明（tooltip）
+ * @param {string|null} reason
+ * @returns {string}
+ */
+export function getCacheUnavailableTooltip(reason) {
+	switch (reason) {
+		case CACHE_UNAVAILABLE_REASON.FORMAT_CHAT_COMPLETIONS:
+			return '提示词缓存仅在 Anthropic Messages 格式下可用。可在设置中将 API 格式改为「自动」或「Anthropic Messages」，并选用 Claude 模型。';
+		case CACHE_UNAVAILABLE_REASON.BACKEND_PROXY:
+			return '后端代理只暴露 Chat Completions 端点，无 /v1/messages，无法使用提示词缓存。';
+		case CACHE_UNAVAILABLE_REASON.GEMINI_PROTOCOL:
+			return '当前为 Gemini 原生通道，不支持 Anthropic 风格的提示词缓存。';
+		default:
+			return '当前条件下提示词缓存不可用。';
+	}
+}
+
+/**
+ * 去掉消息上的手动缓存断点（缓存不可用时发送前剥离，避免仍注入 cache_control）
+ * @param {Array} messages
+ * @returns {Array}
+ */
+export function stripCacheBreakpoints(messages) {
+	if (!Array.isArray(messages)) return messages;
+	return messages.map((m) => {
+		if (!m || m.cacheBreakpoint == null) return m;
+		const next = { ...m };
+		delete next.cacheBreakpoint;
+		return next;
+	});
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 做了什么

按方案落地 API 格式显式切换，并在缓存不可用时明确展示。

### 行为

1. **设置 → API 格式**：自动 / Chat Completions / Anthropic Messages  
   - Gemini 预设隐藏该项  
   - 后端代理禁用并固定 Chat Completions  
2. **自动模式**：Claude 模型（含 `anthropic/claude-*`）走 `/v1/messages`，以便启用 Prompt Cache  
3. **缓存仅在 Anthropic Messages 路径可用**；不可用时：  
   - 顶部「关/5m/1h」禁用 + 旁注原因  
   - 消息金币入口展示不可用说明，不显示自动 A 徽章  
4. 偏好持久化：`bs2_request_format`（默认 `auto`）

### 主要改动

- 新增 `src/utils/requestFormat.js`
- `aiService.js` 按偏好路由，不可用时剥离 `cache_control`
- `SettingsDrawer` / `ModelSelector` / `MessageControls` UI
- 三模式传入 `requestFormat`

设计文档：`docs/api/API格式与缓存切换方案.md`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6cf42515-8cd9-4976-a8db-cdc26d84ece6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6cf42515-8cd9-4976-a8db-cdc26d84ece6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

