### PR TITLE
feat: 接入 OpenAI Responses API

### DIFF
--- a/docs/api/API格式与缓存切换方案.md
+++ b/docs/api/API格式与缓存切换方案.md
@@ -1,7 +1,7 @@
 # API 格式显式切换与缓存可用性方案
 
-> 状态：已实现
-> 背景：当前已支持 Chat Completions 与 Anthropic Messages（Claude Code 同系）两条请求路径；本方案补齐显式格式切换与缓存不可用 UI。
+> 状态：已实现（含 Responses）
+> 背景：支持 Chat Completions、Anthropic Messages、OpenAI Responses 三条请求路径；格式可显式切换；缓存不可用时 UI 明确展示。
 
 ---
 

--- a/docs/api/Responses-API支持.md
+++ b/docs/api/Responses-API支持.md
@@ -1,0 +1,31 @@
+# Responses API 支持说明
+
+## 入口
+
+设置 → **API 格式** → `Responses`（`bs2_request_format = responses`）
+
+自动模式不会切到 Responses；Claude 仍走 Anthropic Messages，其余走 Chat Completions。需要 Responses 时请显式选择。
+
+## 行为
+
+| 项 | 实现 |
+|----|------|
+| 端点 | `{base}/v1/responses` |
+| 输入 | `messages` → `instructions`（system/developer）+ `input`（user/assistant） |
+| 输出 | `output_text` / `output[].message`；流式 `response.output_text.delta` |
+| 推理 | `response.reasoning_summary_text.delta` / `response.reasoning_text.delta` |
+| 结构化输出 | `extraBody.response_format` → `text.format` |
+| 多轮 | 手动回传历史；默认 `store: false` |
+| 缺失端点 | 404/405/5xx 回退 Chat Completions |
+
+驱动：`src/utils/providers/openaiResponses.js`
+
+## 缓存
+
+Anthropic 风格 Prompt Cache（关/5m/1h）在 Responses 下不可用，UI 会禁用并注明原因。Responses 自身的服务端缓存与该开关无关。
+
+## 未做（可后续）
+
+- Conversations API / UI 侧 `previous_response_id` 链路
+- 内置工具（web_search 等）与服务端自动 tool loop
+- DrawMode `modalities` 图像生成（仍建议 Chat Completions / Gemini）

--- a/src/components/SettingsDrawer.vue
+++ b/src/components/SettingsDrawer.vue
@@ -143,10 +143,12 @@
 						v-model="innerRequestFormat"
 						:disabled="isRequestFormatLocked"
 						size="small"
+						class="request-format-group"
 					>
 						<el-radio-button label="auto">自动</el-radio-button>
 						<el-radio-button label="chat_completions">Chat Completions</el-radio-button>
 						<el-radio-button label="anthropic_messages">Anthropic Messages</el-radio-button>
+						<el-radio-button label="responses">Responses</el-radio-button>
 					</el-radio-group>
 					<div class="mt-1 text-gray-600 text-sm">
 						{{ requestFormatHint }}
@@ -538,7 +540,7 @@ export default {
 		},
 		requestFormatHint() {
 			if (this.isRequestFormatLocked) {
-				return '后端代理固定使用 Chat Completions（无 /v1/messages），提示词缓存不可用。';
+				return '后端代理固定使用 Chat Completions，提示词缓存不可用。';
 			}
 			const pref = this.innerRequestFormat;
 			if (pref === REQUEST_FORMAT.CHAT_COMPLETIONS) {
@@ -547,7 +549,10 @@ export default {
 			if (pref === REQUEST_FORMAT.ANTHROPIC_MESSAGES) {
 				return '始终走 /v1/messages（Claude Code 同系）。需中转支持该端点；可启用提示词缓存。';
 			}
-			return '自动：Claude 模型走 Anthropic Messages（可启用缓存），其余走 Chat Completions。';
+			if (pref === REQUEST_FORMAT.RESPONSES) {
+				return '始终走 /v1/responses（OpenAI 推荐接口）。适合推理模型与结构化输出；需中转支持该端点。Anthropic 风格缓存不可用。';
+			}
+			return '自动：Claude 模型走 Anthropic Messages（可启用缓存），其余走 Chat Completions。可手动选 Responses。';
 		},
 		innerProxyBaseUrl: {
 			get() {
@@ -836,6 +841,12 @@ export default {
 
 :deep(.changelog-entry-btn.el-button) {
 	justify-content: space-between;
+}
+
+.request-format-group {
+	display: flex;
+	flex-wrap: wrap;
+	row-gap: 6px;
 }
 
 

--- a/src/core/services/aiService.js
+++ b/src/core/services/aiService.js
@@ -7,6 +7,7 @@
 import { callModelOpenAICompatible } from '@/utils/providers/openaiCompatible';
 import { callModelGemini } from '@/utils/providers/gemini';
 import { callModelAnthropicNative } from '@/utils/providers/anthropic';
+import { callModelOpenAIResponses } from '@/utils/providers/openaiResponses';
 import { listModelsFromPresets } from '@/config/presets';
 import { normalizeMaxTokens } from '@/utils/tokenLimits.js';
 import {
@@ -121,7 +122,7 @@ function prepareCacheInputs(messages, promptCacheTtl, cacheAvailable) {
 /**
  * 核心AI调用方法
  * @param {Object} options - 配置选项
- * @param {string} [options.requestFormat] - API 格式偏好：auto | chat_completions | anthropic_messages
+ * @param {string} [options.requestFormat] - API 格式偏好：auto | chat_completions | anthropic_messages | responses
  */
 export async function callAiModel({
 	provider,
@@ -215,29 +216,32 @@ export async function callAiModel({
 		});
 	}
 
+	const sharedArgs = {
+		apiKey,
+		model: finalModel,
+		messages: cacheInputs.messages,
+		temperature,
+		maxTokens: safeMaxTokens,
+		signal,
+		onChunk,
+		featurePassword,
+		isBackendProxy: isBackendProxy,
+		stream,
+		extraBody,
+		promptCacheTtl: cacheInputs.promptCacheTtl
+	};
+
 	// Anthropic Messages：走原生端点才能让 prompt caching 生效并回传缓存计数。
 	// 后端代理无 /v1/messages，resolveRequestFormat 已强制 chat_completions。
 	// 中转若无该端点（404/405/5xx），回退 OpenAI 兼容路径。
 	if (effectiveFormat === REQUEST_FORMAT.ANTHROPIC_MESSAGES && !isBackendProxy) {
-		const nativeArgs = {
-			apiUrl: normalizedUrl,
-			apiKey,
-			model: finalModel,
-			messages: cacheInputs.messages,
-			temperature,
-			maxTokens: safeMaxTokens,
-			signal,
-			onChunk,
-			featurePassword,
-			isBackendProxy: isBackendProxy,
-			stream,
-			extraBody,
-			promptCacheTtl: cacheInputs.promptCacheTtl
-		};
 		try {
 			console.log('[Core AI Service] Routing to Anthropic Messages for', finalModel,
 				'(pref:', formatPref + ')');
-			return await callModelAnthropicNative(nativeArgs);
+			return await callModelAnthropicNative({
+				...sharedArgs,
+				apiUrl: normalizedUrl
+			});
 		} catch (err) {
 			const status = err?.status;
 			const isMissingEndpoint = err?.isAnthropicNativeError
@@ -248,21 +252,29 @@ export async function callAiModel({
 		}
 	}
 
+	// OpenAI Responses API（/v1/responses）
+	if (effectiveFormat === REQUEST_FORMAT.RESPONSES && !isBackendProxy) {
+		try {
+			console.log('[Core AI Service] Routing to Responses API for', finalModel,
+				'(pref:', formatPref + ')');
+			return await callModelOpenAIResponses({
+				...sharedArgs,
+				apiUrl: normalizedUrl
+			});
+		} catch (err) {
+			const status = err?.status;
+			const isMissingEndpoint = err?.isResponsesApiError
+				&& (status === 404 || status === 405 || (status >= 500 && status < 600));
+			if (!isMissingEndpoint) throw err;
+			console.warn('[Core AI Service] Responses endpoint unavailable ('
+				+ status + '), falling back to Chat Completions:', err.message);
+		}
+	}
+
 	return callModelOpenAICompatible({
+		...sharedArgs,
 		apiUrl: finalUrl,
-		apiKey,
-		model: finalModel,
-		messages: cacheInputs.messages,
-		temperature,
-		maxTokens: safeMaxTokens,
-		signal,
-		onChunk,
-		featurePassword,
-		isBackendProxy: isBackendProxy,
-		geminiReasoningEffort,
-		stream,
-		extraBody,
-		promptCacheTtl: cacheInputs.promptCacheTtl
+		geminiReasoningEffort
 	});
 }
 

--- a/src/modes/GameMode/runtime/responseFormat.js
+++ b/src/modes/GameMode/runtime/responseFormat.js
@@ -108,6 +108,7 @@ export function hasGameResponseFormat(extraBody) {
 export function isResponseFormatUnsupportedError(error) {
 	const message = String(error?.message || error || '').toLowerCase();
 	return message.includes('response_format')
+		|| message.includes('text.format')
 		|| message.includes('json_schema')
 		|| message.includes('structured output')
 		|| message.includes('structured outputs')

--- a/src/utils/providers/openaiResponses.js
+++ b/src/utils/providers/openaiResponses.js
@@ -1,0 +1,383 @@
+import { normalizeOpenAiUsage } from '@/utils/tokenUsage.js';
+import { normalizeMaxTokens } from '@/utils/tokenLimits.js';
+
+/**
+ * OpenAI Responses API（POST /v1/responses）
+ *
+ * Chat Completions 的进化版。本驱动把现有 OpenAI 风格 messages 转为
+ * instructions + input，解析 output / 流式语义事件，向上返回与其他驱动
+ * 相同形状的 assistantMessage。
+ *
+ * 多轮：默认手动回传历史（store: false），不依赖 previous_response_id。
+ * 结构化输出：把 extraBody.response_format 映射为 text.format。
+ */
+
+const RESPONSES_EXTRA_KEYS = [
+	'top_p', 'tools', 'tool_choice', 'metadata', 'user',
+	'previous_response_id', 'store', 'truncation', 'parallel_tool_calls',
+	'prompt_cache_key', 'safety_identifier', 'service_tier',
+	'reasoning', 'include', 'background', 'conversation'
+];
+
+/**
+ * baseUrl → /v1/responses
+ */
+export function ensureResponsesEndpoint(apiUrl) {
+	if (!apiUrl) return apiUrl;
+	let url = String(apiUrl).trim();
+	if (!url) return url;
+	if (/\/v1\/responses(?:\?|$)/i.test(url)) return url;
+	if (url.includes('/chat/completions')) {
+		return url.replace('/chat/completions', '/responses');
+	}
+	if (url.includes('/messages')) {
+		return url.replace('/messages', '/responses');
+	}
+	url = url.endsWith('/') ? url.slice(0, -1) : url;
+	if (/\/v\d+(?:beta)?$/i.test(url)) return url + '/responses';
+	return url + '/v1/responses';
+}
+
+function contentToText(content) {
+	if (typeof content === 'string') return content;
+	if (Array.isArray(content)) {
+		return content.map((block) => {
+			if (typeof block === 'string') return block;
+			if (typeof block?.text === 'string') return block.text;
+			return '';
+		}).join('');
+	}
+	if (content == null) return '';
+	return String(content);
+}
+
+/**
+ * messages → { instructions?, input }
+ * system/developer 抽到 instructions；其余 user/assistant 进 input。
+ */
+export function buildResponsesInput(messages) {
+	const instructionParts = [];
+	const input = [];
+
+	if (!Array.isArray(messages)) {
+		return { instructions: undefined, input: [] };
+	}
+
+	for (const message of messages) {
+		if (!message || typeof message !== 'object') continue;
+		const role = message.role;
+		const text = contentToText(message.content);
+
+		if (role === 'system' || role === 'developer') {
+			if (text) instructionParts.push(text);
+			continue;
+		}
+		if (role === 'user' || role === 'assistant') {
+			input.push({
+				role,
+				content: text
+			});
+		}
+	}
+
+	return {
+		instructions: instructionParts.length > 0 ? instructionParts.join('\n\n') : undefined,
+		input
+	};
+}
+
+/**
+ * Chat Completions 的 response_format → Responses 的 text.format
+ */
+export function convertResponseFormatToTextFormat(responseFormat) {
+	if (!responseFormat || typeof responseFormat !== 'object') return null;
+	const type = responseFormat.type;
+	if (type === 'json_object') {
+		return { type: 'json_object' };
+	}
+	if (type === 'text') {
+		return { type: 'text' };
+	}
+	if (type === 'json_schema') {
+		const schemaWrapper = responseFormat.json_schema || {};
+		const format = {
+			type: 'json_schema',
+			name: schemaWrapper.name || 'response',
+			schema: schemaWrapper.schema || { type: 'object' }
+		};
+		if (schemaWrapper.strict !== undefined) {
+			format.strict = schemaWrapper.strict;
+		}
+		if (schemaWrapper.description) {
+			format.description = schemaWrapper.description;
+		}
+		return format;
+	}
+	return null;
+}
+
+function pickResponsesExtraBody(extraBody = {}) {
+	const out = {};
+	if (!extraBody || typeof extraBody !== 'object') return out;
+
+	for (const key of RESPONSES_EXTRA_KEYS) {
+		if (key in extraBody && extraBody[key] !== undefined) {
+			out[key] = extraBody[key];
+		}
+	}
+
+	if (extraBody.reasoning_effort && !out.reasoning) {
+		out.reasoning = { effort: extraBody.reasoning_effort };
+	}
+
+	const textFormat = convertResponseFormatToTextFormat(extraBody.response_format);
+	if (textFormat) {
+		out.text = {
+			...(typeof extraBody.text === 'object' ? extraBody.text : {}),
+			format: textFormat
+		};
+	} else if (extraBody.text && typeof extraBody.text === 'object') {
+		out.text = extraBody.text;
+	}
+
+	return out;
+}
+
+export function extractResponsesOutputText(response) {
+	if (!response || typeof response !== 'object') return '';
+	if (typeof response.output_text === 'string' && response.output_text) {
+		return response.output_text;
+	}
+	const parts = [];
+	for (const item of response.output || []) {
+		if (item?.type !== 'message' || !Array.isArray(item.content)) continue;
+		for (const block of item.content) {
+			if (block?.type === 'output_text' && typeof block.text === 'string') {
+				parts.push(block.text);
+			}
+		}
+	}
+	return parts.join('');
+}
+
+export function extractResponsesReasoning(response) {
+	if (!response || typeof response !== 'object') return '';
+	const parts = [];
+	for (const item of response.output || []) {
+		if (item?.type !== 'reasoning') continue;
+		if (Array.isArray(item.summary)) {
+			for (const summary of item.summary) {
+				if (typeof summary?.text === 'string' && summary.text) {
+					parts.push(summary.text);
+				}
+			}
+		}
+		if (Array.isArray(item.content)) {
+			for (const block of item.content) {
+				if (
+					(block?.type === 'reasoning_text' || block?.type === 'summary_text')
+					&& typeof block.text === 'string'
+					&& block.text
+				) {
+					parts.push(block.text);
+				}
+			}
+		}
+	}
+	return parts.join('\n');
+}
+
+function extractImages(response) {
+	const images = [];
+	for (const item of response?.output || []) {
+		if (item?.type !== 'message' || !Array.isArray(item.content)) continue;
+		for (const block of item.content) {
+			if (block?.type === 'output_image' && block.image_url) {
+				images.push({ image_url: { url: block.image_url } });
+			}
+		}
+	}
+	return images;
+}
+
+function applyCompletedResponse(newMessage, response) {
+	if (!response || typeof response !== 'object') return;
+	const text = extractResponsesOutputText(response);
+	if (text) newMessage.content = text;
+	const reasoning = extractResponsesReasoning(response);
+	if (reasoning) newMessage.reasoning_content = reasoning;
+	const images = extractImages(response);
+	if (images.length) newMessage.images = images;
+	if (response.id) newMessage.responseId = response.id;
+	if (response.usage) {
+		newMessage.usage = normalizeOpenAiUsage(response.usage);
+	}
+	if (response.error) {
+		const msg = response.error.message || response.error.code || '未知错误';
+		throw new Error(`API错误: ${msg}`);
+	}
+	if (response.status === 'failed') {
+		throw new Error(`API错误: Responses 请求失败（status=failed）`);
+	}
+}
+
+function createResponsesError(message, status) {
+	const err = new Error(message);
+	err.status = status;
+	err.isResponsesApiError = true;
+	return err;
+}
+
+/**
+ * @returns {Promise<{role, content, reasoning_content, timestamp, images, usage, responseId?}>}
+ */
+export async function callModelOpenAIResponses({
+	apiUrl,
+	apiKey,
+	model,
+	messages,
+	temperature = 0.7,
+	maxTokens = 4096,
+	signal,
+	onChunk,
+	featurePassword,
+	isBackendProxy,
+	stream = true,
+	extraBody = {}
+}) {
+	const endpoint = ensureResponsesEndpoint(apiUrl);
+	const safeMaxTokens = normalizeMaxTokens(maxTokens, 4096);
+	const { instructions, input } = buildResponsesInput(messages);
+	const mappedExtra = pickResponsesExtraBody(extraBody);
+
+	const requestBody = {
+		model,
+		input,
+		stream,
+		temperature,
+		max_output_tokens: safeMaxTokens,
+		// 浏览器端自行回传历史，默认不落库
+		store: false,
+		...mappedExtra
+	};
+
+	if (instructions) {
+		requestBody.instructions = instructions;
+	}
+
+	// mappedExtra 里若显式传了 store，保留用户值
+	if (mappedExtra.store !== undefined) {
+		requestBody.store = mappedExtra.store;
+	}
+
+	console.log('[Responses API] request:', {
+		endpoint,
+		model,
+		inputCount: Array.isArray(input) ? input.length : 0,
+		hasInstructions: Boolean(instructions),
+		stream,
+		store: requestBody.store,
+		hasTextFormat: Boolean(requestBody.text?.format),
+		hasPreviousResponseId: Boolean(requestBody.previous_response_id)
+	});
+
+	const headers = { 'Content-Type': 'application/json' };
+	if (isBackendProxy) {
+		if (apiKey) headers['x-api-key'] = apiKey;
+		if (featurePassword && featurePassword.trim()) {
+			headers['X-Feature-Password'] = featurePassword;
+		}
+	} else if (apiKey) {
+		headers['Authorization'] = `Bearer ${apiKey}`;
+	}
+
+	const response = await fetch(endpoint, {
+		method: 'POST',
+		headers,
+		signal,
+		body: JSON.stringify(requestBody)
+	});
+
+	if (!response.ok) {
+		const errorText = await response.text();
+		console.error('[Responses API] request failed:', response.status, errorText);
+		const baseMsg = `API请求失败: ${response.status} - ${errorText}`;
+		const hint = response.status === 401
+			? ' 若密钥无误，可能是上游或中转暂时异常，可过半小时重试，不是你的问题（作者遇到过）。'
+			: '';
+		throw createResponsesError(baseMsg + hint, response.status);
+	}
+
+	const newMessage = {
+		role: 'assistant',
+		content: '',
+		reasoning_content: '',
+		timestamp: new Date().toISOString(),
+		images: [],
+		usage: null
+	};
+
+	if (!stream) {
+		const data = await response.json();
+		applyCompletedResponse(newMessage, data);
+		return newMessage;
+	}
+
+	const reader = response.body.getReader();
+	const decoder = new TextDecoder();
+	let buffer = '';
+
+	while (true) {
+		const { done, value } = await reader.read();
+		if (done) break;
+		buffer += decoder.decode(value, { stream: true });
+
+		let idx;
+		while ((idx = buffer.indexOf('\n')) >= 0) {
+			const line = buffer.slice(0, idx).trim();
+			buffer = buffer.slice(idx + 1);
+			if (!line || line.startsWith(':') || line.startsWith('event:')) continue;
+			if (line === 'data: [DONE]' || line === '[DONE]') continue;
+
+			let jsonStr = line.startsWith('data:') ? line.slice(5).trim() : line;
+			if (!jsonStr) continue;
+
+			let event;
+			try {
+				event = JSON.parse(jsonStr);
+			} catch (parseErr) {
+				console.error('[Responses API] SSE parse error:', parseErr, 'line:', line);
+				continue;
+			}
+
+			const type = event?.type;
+			if (!type) continue;
+
+			if (type === 'error' || type === 'response.failed') {
+				const msg = event.error?.message
+					|| event.response?.error?.message
+					|| event.message
+					|| 'Responses 流式错误';
+				throw new Error(`API错误: ${msg}`);
+			}
+
+			if (type === 'response.output_text.delta' && typeof event.delta === 'string') {
+				newMessage.content += event.delta;
+			} else if (type === 'response.reasoning_summary_text.delta' && typeof event.delta === 'string') {
+				newMessage.reasoning_content += event.delta;
+			} else if (type === 'response.reasoning_text.delta' && typeof event.delta === 'string') {
+				newMessage.reasoning_content += event.delta;
+			} else if (type === 'response.completed' && event.response) {
+				applyCompletedResponse(newMessage, event.response);
+			} else if (type === 'response.created' && event.response?.id) {
+				newMessage.responseId = event.response.id;
+			}
+
+			if (typeof onChunk === 'function') {
+				onChunk({ ...newMessage });
+			}
+		}
+	}
+
+	return newMessage;
+}

--- a/src/utils/requestFormat.js
+++ b/src/utils/requestFormat.js
@@ -1,17 +1,20 @@
 /**
- * 请求格式（Chat Completions / Anthropic Messages）与 Prompt Cache 可用性
+ * 请求格式与 Prompt Cache 可用性
  *
  * requestFormat 是 OpenAI 兼容底座上的二次路由，与 preset.protocol（openai|gemini）分开。
+ * 可选：auto | chat_completions | anthropic_messages | responses
  */
 
 export const REQUEST_FORMAT = {
 	AUTO: 'auto',
 	CHAT_COMPLETIONS: 'chat_completions',
-	ANTHROPIC_MESSAGES: 'anthropic_messages'
+	ANTHROPIC_MESSAGES: 'anthropic_messages',
+	RESPONSES: 'responses'
 };
 
 export const CACHE_UNAVAILABLE_REASON = {
 	FORMAT_CHAT_COMPLETIONS: 'format_chat_completions',
+	FORMAT_RESPONSES: 'format_responses',
 	BACKEND_PROXY: 'backend_proxy',
 	GEMINI_PROTOCOL: 'gemini_protocol'
 };
@@ -19,12 +22,13 @@ export const CACHE_UNAVAILABLE_REASON = {
 const VALID_PREFS = new Set([
 	REQUEST_FORMAT.AUTO,
 	REQUEST_FORMAT.CHAT_COMPLETIONS,
-	REQUEST_FORMAT.ANTHROPIC_MESSAGES
+	REQUEST_FORMAT.ANTHROPIC_MESSAGES,
+	REQUEST_FORMAT.RESPONSES
 ]);
 
 /**
  * @param {unknown} value
- * @returns {'auto'|'chat_completions'|'anthropic_messages'}
+ * @returns {'auto'|'chat_completions'|'anthropic_messages'|'responses'}
  */
 export function normalizeRequestFormatPref(value) {
 	const v = typeof value === 'string' ? value.trim() : '';
@@ -46,12 +50,7 @@ export function isClaudeModel(model) {
  * 解析本次请求应使用的外壳格式
  * Gemini 通道返回 null（由 gemini 驱动处理，不走本开关）
  *
- * @param {Object} options
- * @param {string} [options.requestFormatPref]
- * @param {string} [options.model]
- * @param {boolean} [options.isBackendProxy]
- * @param {string} [options.protocol] 'openai' | 'gemini'
- * @returns {'chat_completions'|'anthropic_messages'|null}
+ * @returns {'chat_completions'|'anthropic_messages'|'responses'|null}
  */
 export function resolveRequestFormat({
 	requestFormatPref = REQUEST_FORMAT.AUTO,
@@ -65,6 +64,7 @@ export function resolveRequestFormat({
 	const pref = normalizeRequestFormatPref(requestFormatPref);
 	if (pref === REQUEST_FORMAT.CHAT_COMPLETIONS) return REQUEST_FORMAT.CHAT_COMPLETIONS;
 	if (pref === REQUEST_FORMAT.ANTHROPIC_MESSAGES) return REQUEST_FORMAT.ANTHROPIC_MESSAGES;
+	if (pref === REQUEST_FORMAT.RESPONSES) return REQUEST_FORMAT.RESPONSES;
 
 	return isClaudeModel(model)
 		? REQUEST_FORMAT.ANTHROPIC_MESSAGES
@@ -73,6 +73,7 @@ export function resolveRequestFormat({
 
 /**
  * Prompt Cache 是否可用，及不可用原因
+ * 仅 Anthropic Messages 路径开放 Anthropic 风格 cache_control。
  *
  * @returns {{ available: boolean, reason: string|null, effectiveFormat: string|null }}
  */
@@ -104,17 +105,25 @@ export function getPromptCacheAvailability({
 		protocol
 	});
 
-	if (effectiveFormat !== REQUEST_FORMAT.ANTHROPIC_MESSAGES) {
+	if (effectiveFormat === REQUEST_FORMAT.ANTHROPIC_MESSAGES) {
+		return {
+			available: true,
+			reason: null,
+			effectiveFormat
+		};
+	}
+
+	if (effectiveFormat === REQUEST_FORMAT.RESPONSES) {
 		return {
 			available: false,
-			reason: CACHE_UNAVAILABLE_REASON.FORMAT_CHAT_COMPLETIONS,
+			reason: CACHE_UNAVAILABLE_REASON.FORMAT_RESPONSES,
 			effectiveFormat
 		};
 	}
 
 	return {
-		available: true,
-		reason: null,
+		available: false,
+		reason: CACHE_UNAVAILABLE_REASON.FORMAT_CHAT_COMPLETIONS,
 		effectiveFormat
 	};
 }
@@ -124,7 +133,6 @@ export function isPromptCacheAvailable(options) {
 }
 
 /**
- * 缓存不可用时的短文案（模型栏旁注）
  * @param {string|null} reason
  * @returns {string}
  */
@@ -132,6 +140,8 @@ export function getCacheUnavailableLabel(reason) {
 	switch (reason) {
 		case CACHE_UNAVAILABLE_REASON.FORMAT_CHAT_COMPLETIONS:
 			return '缓存不可用 · 当前为 Chat Completions';
+		case CACHE_UNAVAILABLE_REASON.FORMAT_RESPONSES:
+			return '缓存不可用 · 当前为 Responses';
 		case CACHE_UNAVAILABLE_REASON.BACKEND_PROXY:
 			return '缓存不可用 · 代理无 Messages 端点';
 		case CACHE_UNAVAILABLE_REASON.GEMINI_PROTOCOL:
@@ -142,7 +152,6 @@ export function getCacheUnavailableLabel(reason) {
 }
 
 /**
- * 缓存不可用时的详细说明（tooltip）
  * @param {string|null} reason
  * @returns {string}
  */
@@ -150,6 +159,8 @@ export function getCacheUnavailableTooltip(reason) {
 	switch (reason) {
 		case CACHE_UNAVAILABLE_REASON.FORMAT_CHAT_COMPLETIONS:
 			return '提示词缓存仅在 Anthropic Messages 格式下可用。可在设置中将 API 格式改为「自动」或「Anthropic Messages」，并选用 Claude 模型。';
+		case CACHE_UNAVAILABLE_REASON.FORMAT_RESPONSES:
+			return '当前为 OpenAI Responses 格式。Anthropic 风格提示词缓存不可用；Responses 有自己的服务端缓存机制（与本开关无关）。';
 		case CACHE_UNAVAILABLE_REASON.BACKEND_PROXY:
 			return '后端代理只暴露 Chat Completions 端点，无 /v1/messages，无法使用提示词缓存。';
 		case CACHE_UNAVAILABLE_REASON.GEMINI_PROTOCOL:
@@ -160,7 +171,6 @@ export function getCacheUnavailableTooltip(reason) {
 }
 
 /**
- * 去掉消息上的手动缓存断点（缓存不可用时发送前剥离，避免仍注入 cache_control）
  * @param {Array} messages
  * @returns {Array}
  */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 做了什么

在现有 API 格式基建上接入 **OpenAI Responses API**（`POST /v1/responses`）。

### 使用方式

设置 → **API 格式** → 选择 `Responses`

- 自动模式仍：Claude → Anthropic Messages，其余 → Chat Completions  
- 需要 Responses 时请显式选择（避免中转无该端点时误切）

### 能力

| 项 | 说明 |
|----|------|
| 请求转换 | `messages` → `instructions` + `input` |
| 流式 | `response.output_text.delta` / reasoning 相关事件 |
| 非流式 | `output_text` / `output` 解析 |
| 结构化输出 | `response_format` → `text.format`（GameMode 可用） |
| 多轮 | 手动回传历史，默认 `store: false` |
| 回退 | 端点 404/405/5xx → Chat Completions |
| 缓存 UI | Responses 下 Anthropic 风格缓存标记为不可用 |

### 主要文件

- `src/utils/providers/openaiResponses.js`（新驱动）
- `src/utils/requestFormat.js` / `aiService.js` / `SettingsDrawer.vue`
- `docs/api/Responses-API支持.md`

### 后续可做

Conversations / `previous_response_id` UI、内置工具自动循环、DrawMode 图像生成适配。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6cf42515-8cd9-4976-a8db-cdc26d84ece6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6cf42515-8cd9-4976-a8db-cdc26d84ece6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

