### PR TITLE
fix: 区分 Claude 手动缓存与中转自动缓存的 UI 文案

### DIFF
--- a/docs/api/API格式与缓存切换方案.md
+++ b/docs/api/API格式与缓存切换方案.md
@@ -139,15 +139,16 @@ Gemini 预设下：隐藏或禁用该项。
 当 `!isPromptCacheAvailable`：
 
 1. 关 / 5m / 1h **整组 disabled**
-2. 旁注文案，例如：`缓存不可用 · 当前为 Chat Completions`
+2. 旁注文案，例如：`中转自动缓存 · 无需手动设置`（非 Claude）或 `Claude 手动缓存不可用 · 当前为 Chat Completions`（Claude 强制 Completions）
 3. tooltip 写清原因（见下表）
 4. 若用户此前选了 5m/1h，**保留偏好值**但运行时不注入 `cache_control`；恢复可用后无需重选
 
 | 原因码 | 界面文案 |
 |--------|----------|
-| `format_chat_completions` | 当前 API 格式为 Chat Completions，缓存仅在 Anthropic Messages 下可用 |
-| `backend_proxy` | 后端代理无 Messages 端点，缓存不可用 |
-| `gemini_protocol` | Gemini 通道不支持此缓存机制 |
+| `auto_cache_only` | 除 Claude 外由中转自动缓存，无需手动设置关/5m/1h |
+| `format_chat_completions` | Claude 强制 Chat Completions，手动缓存仅在 Anthropic Messages 下可用 |
+| `backend_proxy` | 后端代理无 Messages 端点，Claude 手动缓存不可用；其余模型仍自动缓存 |
+| `gemini_protocol` | 同 `auto_cache_only`（Gemini 等非 Claude 通道） |
 | （可用） | 现有说明保留 |
 
 ### 5.3 消息侧缓存入口（金币 / A 徽章）

--- a/docs/api/API格式与缓存切换方案.md
+++ b/docs/api/API格式与缓存切换方案.md
@@ -139,7 +139,7 @@ Gemini 预设下：隐藏或禁用该项。
 当 `!isPromptCacheAvailable`：
 
 1. 关 / 5m / 1h **整组 disabled**
-2. 旁注文案，例如：`中转自动缓存 · 无需手动设置`（非 Claude）或 `Claude 手动缓存不可用 · 当前为 Chat Completions`（Claude 强制 Completions）
+2. 旁注文案（桌面端）：`自动缓存`（非 Claude）或 `需 Messages`（Claude 强制 Completions/Responses）；**手机端隐藏旁注**，仅保留问号 tooltip
 3. tooltip 写清原因（见下表）
 4. 若用户此前选了 5m/1h，**保留偏好值**但运行时不注入 `cache_control`；恢复可用后无需重选
 

--- a/src/components/ModelSelector.vue
+++ b/src/components/ModelSelector.vue
@@ -275,8 +275,7 @@ export default {
 	}
 
 	.cache-unavailable-label {
-		white-space: normal;
-		line-height: 1.3;
+		display: none;
 	}
 }
 

--- a/src/components/ModelSelector.vue
+++ b/src/components/ModelSelector.vue
@@ -22,28 +22,29 @@
 				/>
 			</el-select>
 
-			<span class="cache-divider"></span>
+			<template v-if="showPromptCacheControls">
+				<span class="cache-divider"></span>
 
-			<span class="model-label">缓存:</span>
-			<el-radio-group
-				:model-value="promptCacheTtl || ''"
-				:disabled="!cacheAvailable"
-				@update:model-value="handleCacheChange"
-				size="small"
-				class="cache-radio-group"
-				:class="{ 'is-unavailable': !cacheAvailable }"
-			>
-				<el-radio-button label="">关</el-radio-button>
-				<el-radio-button label="5m">5m</el-radio-button>
-				<el-radio-button label="1h">1h</el-radio-button>
-			</el-radio-group>
-			<span v-if="!cacheAvailable" class="cache-unavailable-label">{{ unavailableLabel }}</span>
-			<el-tooltip
-				:content="helpContent"
-				placement="bottom"
-			>
-				<el-icon class="cache-help-icon"><QuestionFilled /></el-icon>
-			</el-tooltip>
+				<span class="model-label">缓存:</span>
+				<el-radio-group
+					:model-value="promptCacheTtl || ''"
+					:disabled="!cacheAvailable"
+					@update:model-value="handleCacheChange"
+					size="small"
+					class="cache-radio-group"
+					:class="{ 'is-unavailable': !cacheAvailable }"
+				>
+					<el-radio-button label="">关</el-radio-button>
+					<el-radio-button label="5m">5m</el-radio-button>
+					<el-radio-button label="1h">1h</el-radio-button>
+				</el-radio-group>
+				<el-tooltip
+					:content="helpContent"
+					placement="bottom"
+				>
+					<el-icon class="cache-help-icon"><QuestionFilled /></el-icon>
+				</el-tooltip>
+			</template>
 		</div>
 	</div>
 </template>
@@ -51,12 +52,12 @@
 <script>
 import { QuestionFilled } from '@element-plus/icons-vue';
 import {
-	getCacheUnavailableLabel,
-	getCacheUnavailableTooltip
+	getCacheUnavailableTooltip,
+	shouldShowPromptCacheControls
 } from '@/utils/requestFormat.js';
 
 const CACHE_HELP_AVAILABLE =
-	'Claude 手动提示词缓存：把重复发送的上下文缓存起来，命中后输入费用大幅降低（约 1 折）。此开关控制「自动补断点」的 TTL（关=不自动补；5m/1h=自动断点的有效期）。可在单条消息上用金币图标手动标记缓存点。仅 Claude + Anthropic Messages 格式下可用；其余模型由中转自动缓存，无需手动设置。';
+	'把重复发送的上下文缓存起来，命中后输入费用更低。关=不自动补断点；5m/1h=自动断点有效期。可在消息上用金币图标手动标记。仅 Claude 可用。';
 
 export default {
 	name: 'ModelSelector',
@@ -70,8 +71,8 @@ export default {
 	},
 	emits: ['update:model', 'update:prompt-cache-ttl'],
 	computed: {
-		unavailableLabel() {
-			return getCacheUnavailableLabel(this.cacheUnavailableReason);
+		showPromptCacheControls() {
+			return shouldShowPromptCacheControls(this.cacheUnavailableReason);
 		},
 		helpContent() {
 			if (!this.cacheAvailable) {
@@ -236,13 +237,6 @@ export default {
 	cursor: not-allowed;
 }
 
-.cache-unavailable-label {
-	font-size: 12px;
-	color: #b45309;
-	white-space: nowrap;
-	flex-shrink: 0;
-}
-
 .cache-help-icon {
 	font-size: 14px;
 	color: #9ca3af;
@@ -272,10 +266,6 @@ export default {
 
 	.cache-radio-group :deep(.el-radio-button__inner) {
 		padding: 4px 8px;
-	}
-
-	.cache-unavailable-label {
-		display: none;
 	}
 }
 

--- a/src/components/ModelSelector.vue
+++ b/src/components/ModelSelector.vue
@@ -56,7 +56,7 @@ import {
 } from '@/utils/requestFormat.js';
 
 const CACHE_HELP_AVAILABLE =
-	'提示词缓存：把重复发送的上下文缓存起来，命中后输入费用大幅降低（约 1 折）。此开关控制「自动补断点」的 TTL（关=不自动补；5m/1h=自动断点的有效期）。可在单条消息上用金币图标手动标记缓存点（自带 TTL，始终生效，与全局混用）。仅 Anthropic Messages 格式下可用。';
+	'Claude 手动提示词缓存：把重复发送的上下文缓存起来，命中后输入费用大幅降低（约 1 折）。此开关控制「自动补断点」的 TTL（关=不自动补；5m/1h=自动断点的有效期）。可在单条消息上用金币图标手动标记缓存点。仅 Claude + Anthropic Messages 格式下可用；其余模型由中转自动缓存，无需手动设置。';
 
 export default {
 	name: 'ModelSelector',

--- a/src/components/SettingsDrawer.vue
+++ b/src/components/SettingsDrawer.vue
@@ -540,19 +540,19 @@ export default {
 		},
 		requestFormatHint() {
 			if (this.isRequestFormatLocked) {
-				return '后端代理固定使用 Chat Completions，提示词缓存不可用。';
+				return '后端代理固定使用 Chat Completions。Claude 手动缓存不可用；其余模型由中转自动缓存。';
 			}
 			const pref = this.innerRequestFormat;
 			if (pref === REQUEST_FORMAT.CHAT_COMPLETIONS) {
-				return '始终走 /v1/chat/completions。提示词缓存不可用。';
+				return '始终走 /v1/chat/completions。Claude 手动缓存不可用；其余模型由中转自动缓存。';
 			}
 			if (pref === REQUEST_FORMAT.ANTHROPIC_MESSAGES) {
-				return '始终走 /v1/messages（Claude Code 同系）。需中转支持该端点；可启用提示词缓存。';
+				return '始终走 /v1/messages（Claude Code 同系）。需中转支持该端点；可启用 Claude 手动提示词缓存。';
 			}
 			if (pref === REQUEST_FORMAT.RESPONSES) {
-				return '始终走 /v1/responses（OpenAI 推荐接口）。适合推理模型与结构化输出；需中转支持该端点。Anthropic 风格缓存不可用。';
+				return '始终走 /v1/responses（OpenAI 推荐接口）。适合推理模型与结构化输出；需中转支持该端点。Claude 手动缓存不可用。';
 			}
-			return '自动：Claude 模型走 Anthropic Messages（可启用缓存），其余走 Chat Completions。可手动选 Responses。';
+			return '自动：Claude 走 Anthropic Messages（可启用手动缓存），其余走 Chat Completions（中转自动缓存）。可手动选 Responses。';
 		},
 		innerProxyBaseUrl: {
 			get() {

--- a/src/modes/StandardChatMode/components/MessageControls.vue
+++ b/src/modes/StandardChatMode/components/MessageControls.vue
@@ -37,6 +37,7 @@
 		</el-tooltip>
 
 		<el-dropdown
+			v-if="showCacheControl"
 			trigger="click"
 			placement="top"
 			:hide-on-click="true"
@@ -103,8 +104,10 @@
 import { CopyDocument, Edit, Refresh, Delete, Share, ArrowUp, ArrowDown, Coin } from '@element-plus/icons-vue';
 import { isAutoBreakpoint, getAutoRole } from '@/utils/promptCache';
 import {
-	getCacheUnavailableLabel,
-	getCacheUnavailableTooltip
+	CACHE_UNAVAILABLE_REASON,
+	getCacheUnavailableSummary,
+	getCacheUnavailableTooltip,
+	shouldShowPromptCacheControls
 } from '@/utils/requestFormat.js';
 
 export default {
@@ -155,6 +158,11 @@ export default {
 	},
 	emits: ['copy', 'edit', 'regenerate', 'delete', 'toggle-reasoning', 'fork', 'toggle-collapse', 'cache-breakpoint'],
 	computed: {
+		showCacheControl() {
+			if (this.cacheAvailable) return true;
+			if (this.cacheBadge) return true;
+			return shouldShowPromptCacheControls(this.cacheUnavailableReason);
+		},
 		cacheBadge() {
 			const v = this.message?.cacheBreakpoint;
 			return v === '5m' || v === '1h' ? v : '';
@@ -179,7 +187,9 @@ export default {
 			return isAutoBreakpoint(cleared, this.index);
 		},
 		cacheAriaLabel() {
-			if (!this.cacheAvailable) return getCacheUnavailableLabel(this.cacheUnavailableReason);
+			if (!this.cacheAvailable) {
+				return getCacheUnavailableSummary(this.cacheUnavailableReason);
+			}
 			if (this.cacheBadge) return `缓存点：${this.cacheBadge === '5m' ? '5 分钟' : '1 小时'}（手动）`;
 			if (this.isAuto) return '自动缓存点，点击可手动覆盖';
 			return '标记为缓存点';
@@ -190,7 +200,7 @@ export default {
 		// 下拉菜单首行：当前状态说明（手机无 tooltip 也能看到）
 		statusLine() {
 			if (!this.cacheAvailable) {
-				return getCacheUnavailableLabel(this.cacheUnavailableReason);
+				return getCacheUnavailableSummary(this.cacheUnavailableReason);
 			}
 			if (this.cacheBadge) {
 				return `当前：手动 · ${this.cacheBadge === '5m' ? '5 分钟' : '1 小时'}`;

--- a/src/utils/requestFormat.js
+++ b/src/utils/requestFormat.js
@@ -146,17 +146,17 @@ export function isPromptCacheAvailable(options) {
 export function getCacheUnavailableLabel(reason) {
 	switch (reason) {
 		case CACHE_UNAVAILABLE_REASON.AUTO_CACHE_ONLY:
-			return '中转自动缓存 · 无需手动设置';
+			return '自动缓存';
 		case CACHE_UNAVAILABLE_REASON.FORMAT_CHAT_COMPLETIONS:
-			return 'Claude 手动缓存不可用 · 当前为 Chat Completions';
+			return '需 Messages';
 		case CACHE_UNAVAILABLE_REASON.FORMAT_RESPONSES:
-			return 'Claude 手动缓存不可用 · 当前为 Responses';
+			return '需 Messages';
 		case CACHE_UNAVAILABLE_REASON.BACKEND_PROXY:
-			return 'Claude 手动缓存不可用 · 代理无 Messages 端点';
+			return '无 Messages';
 		case CACHE_UNAVAILABLE_REASON.GEMINI_PROTOCOL:
-			return '中转自动缓存 · 无需手动设置';
+			return '自动缓存';
 		default:
-			return '手动缓存不可用';
+			return '不可用';
 	}
 }
 

--- a/src/utils/requestFormat.js
+++ b/src/utils/requestFormat.js
@@ -139,25 +139,35 @@ export function isPromptCacheAvailable(options) {
 	return getPromptCacheAvailability(options).available;
 }
 
+/** 是否在 UI 展示手动缓存控件（非 Claude 自动缓存时不展示） */
+export function shouldShowPromptCacheControls(reason) {
+	if (!reason) return true;
+	return reason !== CACHE_UNAVAILABLE_REASON.AUTO_CACHE_ONLY;
+}
+
+/**
+ * 下拉/旁注等一行说明（plain language）
+ * @param {string|null} reason
+ * @returns {string}
+ */
+export function getCacheUnavailableSummary(reason) {
+	switch (reason) {
+		case CACHE_UNAVAILABLE_REASON.FORMAT_CHAT_COMPLETIONS:
+		case CACHE_UNAVAILABLE_REASON.FORMAT_RESPONSES:
+			return '请在设置中切换 API 格式';
+		case CACHE_UNAVAILABLE_REASON.BACKEND_PROXY:
+			return '当前代理不支持';
+		default:
+			return '当前不可用';
+	}
+}
+
 /**
  * @param {string|null} reason
  * @returns {string}
  */
 export function getCacheUnavailableLabel(reason) {
-	switch (reason) {
-		case CACHE_UNAVAILABLE_REASON.AUTO_CACHE_ONLY:
-			return '自动缓存';
-		case CACHE_UNAVAILABLE_REASON.FORMAT_CHAT_COMPLETIONS:
-			return '需 Messages';
-		case CACHE_UNAVAILABLE_REASON.FORMAT_RESPONSES:
-			return '需 Messages';
-		case CACHE_UNAVAILABLE_REASON.BACKEND_PROXY:
-			return '无 Messages';
-		case CACHE_UNAVAILABLE_REASON.GEMINI_PROTOCOL:
-			return '自动缓存';
-		default:
-			return '不可用';
-	}
+	return getCacheUnavailableSummary(reason);
 }
 
 /**
@@ -167,17 +177,17 @@ export function getCacheUnavailableLabel(reason) {
 export function getCacheUnavailableTooltip(reason) {
 	switch (reason) {
 		case CACHE_UNAVAILABLE_REASON.AUTO_CACHE_ONLY:
-			return '除 Claude 外，其余模型经中转自动缓存，无需设置关/5m/1h。此开关仅用于 Claude：需在设置中选「自动」或「Anthropic Messages」，并选用 Claude 模型。';
+			return '当前模型无需手动设置，缓存由服务自动处理。顶部「关/5m/1h」仅 Claude 可用。';
 		case CACHE_UNAVAILABLE_REASON.FORMAT_CHAT_COMPLETIONS:
-			return 'Claude 的手动提示词缓存（关/5m/1h、消息金币标记）仅在 Anthropic Messages 格式下生效。可在设置中将 API 格式改为「自动」或「Anthropic Messages」。';
+			return '此开关仅 Claude 可用。请在设置 → API 格式 中选择「自动」或「Anthropic Messages」。';
 		case CACHE_UNAVAILABLE_REASON.FORMAT_RESPONSES:
-			return 'Claude 的手动提示词缓存在 OpenAI Responses 格式下不可用；Responses 有自己的服务端缓存（与本开关无关）。';
+			return '此开关仅 Claude 可用。当前为 Responses 格式，请在设置中改回「自动」或「Anthropic Messages」。';
 		case CACHE_UNAVAILABLE_REASON.BACKEND_PROXY:
-			return '后端代理只暴露 Chat Completions 端点，无 /v1/messages，Claude 无法启用手动提示词缓存。其余模型仍由中转自动缓存。';
+			return '当前后端代理不支持 Claude 手动缓存，其余模型仍会自动缓存。';
 		case CACHE_UNAVAILABLE_REASON.GEMINI_PROTOCOL:
-			return '除 Claude 外，其余模型经中转自动缓存，无需设置关/5m/1h。此开关仅用于 Claude（Anthropic Messages 格式）。';
+			return '当前模型无需手动设置，缓存由服务自动处理。';
 		default:
-			return '当前条件下 Claude 手动提示词缓存不可用。';
+			return '当前无法使用手动缓存设置。';
 	}
 }
 

--- a/src/utils/requestFormat.js
+++ b/src/utils/requestFormat.js
@@ -13,10 +13,13 @@ export const REQUEST_FORMAT = {
 };
 
 export const CACHE_UNAVAILABLE_REASON = {
+	/** Claude 等非自动缓存模型：强制 Chat Completions 时无法用手动 cache_control */
 	FORMAT_CHAT_COMPLETIONS: 'format_chat_completions',
 	FORMAT_RESPONSES: 'format_responses',
 	BACKEND_PROXY: 'backend_proxy',
-	GEMINI_PROTOCOL: 'gemini_protocol'
+	GEMINI_PROTOCOL: 'gemini_protocol',
+	/** 非 Claude：走 Chat Completions / Gemini 等，缓存由中转自动处理，无需本开关 */
+	AUTO_CACHE_ONLY: 'auto_cache_only'
 };
 
 const VALID_PREFS = new Set([
@@ -86,14 +89,16 @@ export function getPromptCacheAvailability({
 	if (protocol === 'gemini') {
 		return {
 			available: false,
-			reason: CACHE_UNAVAILABLE_REASON.GEMINI_PROTOCOL,
+			reason: CACHE_UNAVAILABLE_REASON.AUTO_CACHE_ONLY,
 			effectiveFormat: null
 		};
 	}
 	if (isBackendProxy) {
 		return {
 			available: false,
-			reason: CACHE_UNAVAILABLE_REASON.BACKEND_PROXY,
+			reason: isClaudeModel(model)
+				? CACHE_UNAVAILABLE_REASON.BACKEND_PROXY
+				: CACHE_UNAVAILABLE_REASON.AUTO_CACHE_ONLY,
 			effectiveFormat: REQUEST_FORMAT.CHAT_COMPLETIONS
 		};
 	}
@@ -123,7 +128,9 @@ export function getPromptCacheAvailability({
 
 	return {
 		available: false,
-		reason: CACHE_UNAVAILABLE_REASON.FORMAT_CHAT_COMPLETIONS,
+		reason: isClaudeModel(model)
+			? CACHE_UNAVAILABLE_REASON.FORMAT_CHAT_COMPLETIONS
+			: CACHE_UNAVAILABLE_REASON.AUTO_CACHE_ONLY,
 		effectiveFormat
 	};
 }
@@ -138,16 +145,18 @@ export function isPromptCacheAvailable(options) {
  */
 export function getCacheUnavailableLabel(reason) {
 	switch (reason) {
+		case CACHE_UNAVAILABLE_REASON.AUTO_CACHE_ONLY:
+			return '中转自动缓存 · 无需手动设置';
 		case CACHE_UNAVAILABLE_REASON.FORMAT_CHAT_COMPLETIONS:
-			return '缓存不可用 · 当前为 Chat Completions';
+			return 'Claude 手动缓存不可用 · 当前为 Chat Completions';
 		case CACHE_UNAVAILABLE_REASON.FORMAT_RESPONSES:
-			return '缓存不可用 · 当前为 Responses';
+			return 'Claude 手动缓存不可用 · 当前为 Responses';
 		case CACHE_UNAVAILABLE_REASON.BACKEND_PROXY:
-			return '缓存不可用 · 代理无 Messages 端点';
+			return 'Claude 手动缓存不可用 · 代理无 Messages 端点';
 		case CACHE_UNAVAILABLE_REASON.GEMINI_PROTOCOL:
-			return '缓存不可用 · Gemini 通道不支持';
+			return '中转自动缓存 · 无需手动设置';
 		default:
-			return '缓存不可用';
+			return '手动缓存不可用';
 	}
 }
 
@@ -157,16 +166,18 @@ export function getCacheUnavailableLabel(reason) {
  */
 export function getCacheUnavailableTooltip(reason) {
 	switch (reason) {
+		case CACHE_UNAVAILABLE_REASON.AUTO_CACHE_ONLY:
+			return '除 Claude 外，其余模型经中转自动缓存，无需设置关/5m/1h。此开关仅用于 Claude：需在设置中选「自动」或「Anthropic Messages」，并选用 Claude 模型。';
 		case CACHE_UNAVAILABLE_REASON.FORMAT_CHAT_COMPLETIONS:
-			return '提示词缓存仅在 Anthropic Messages 格式下可用。可在设置中将 API 格式改为「自动」或「Anthropic Messages」，并选用 Claude 模型。';
+			return 'Claude 的手动提示词缓存（关/5m/1h、消息金币标记）仅在 Anthropic Messages 格式下生效。可在设置中将 API 格式改为「自动」或「Anthropic Messages」。';
 		case CACHE_UNAVAILABLE_REASON.FORMAT_RESPONSES:
-			return '当前为 OpenAI Responses 格式。Anthropic 风格提示词缓存不可用；Responses 有自己的服务端缓存机制（与本开关无关）。';
+			return 'Claude 的手动提示词缓存在 OpenAI Responses 格式下不可用；Responses 有自己的服务端缓存（与本开关无关）。';
 		case CACHE_UNAVAILABLE_REASON.BACKEND_PROXY:
-			return '后端代理只暴露 Chat Completions 端点，无 /v1/messages，无法使用提示词缓存。';
+			return '后端代理只暴露 Chat Completions 端点，无 /v1/messages，Claude 无法启用手动提示词缓存。其余模型仍由中转自动缓存。';
 		case CACHE_UNAVAILABLE_REASON.GEMINI_PROTOCOL:
-			return '当前为 Gemini 原生通道，不支持 Anthropic 风格的提示词缓存。';
+			return '除 Claude 外，其余模型经中转自动缓存，无需设置关/5m/1h。此开关仅用于 Claude（Anthropic Messages 格式）。';
 		default:
-			return '当前条件下提示词缓存不可用。';
+			return '当前条件下 Claude 手动提示词缓存不可用。';
 	}
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

缓存相关文案（「自动缓存」「需 Messages」等）普通用户看不懂；非 Claude 模型下展示禁用的缓存控件也容易造成困惑。

## 方案

**非 Claude 模型：直接隐藏缓存 UI**
- 顶部不显示「缓存: 关/5m/1h」
- 消息操作栏不显示金币按钮
- 缓存由服务自动处理，用户无需操作

**Claude 但手动缓存不可用时**
- 仍显示禁用的控件 + 问号
- 无旁注徽章
- 下拉/ tooltip 用 plain language：
  - 「请在设置中切换 API 格式」
  - 「当前代理不支持」

## 验证

- GPT / DeepSeek 等非 Claude：看不到任何缓存控件
- Claude + Anthropic Messages：缓存开关正常可用
- Claude + 强制 Completions：看到禁用控件，点 ? 有操作指引

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b45c97c-98ef-4d7d-9635-433faf392b06?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b45c97c-98ef-4d7d-9635-433faf392b06&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

